### PR TITLE
Stream::print(): $glue param added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,12 @@ Quick Reference
 | [`toValue`](#To-Value-1)                     | Reduces stream like array_reduce() function                                      | `$stream->toValue($reducer, $initialValue)`  |
 
 ##### Side Effect Terminal Operations
-| Terminal Operation         | Description                     | Code Snippet           |
-|----------------------------|---------------------------------|------------------------|
-| [`print`](#Print)          | `print` each item in the stream | `$stream->print()`     |
-| [`printLn`](#Print-Ln)     | `print` each item on a new line | `$stream->printLn()`   |
-| [`printR`](#Print-R)       | `print_r` each item             | `$stream->printR()`    |
-| [`var_dump`](#Var-Dump)    | `var_dump` each item            | `$stream->varDump()`   |
+| Terminal Operation         | Description                     | Code Snippet            |
+|----------------------------|---------------------------------|-------------------------|
+| [`print`](#Print)          | `print` each item in the stream | `$stream->print($glue)` |
+| [`printLn`](#Print-Ln)     | `print` each item on a new line | `$stream->printLn()`    |
+| [`printR`](#Print-R)       | `print_r` each item             | `$stream->printR()`     |
+| [`var_dump`](#Var-Dump)    | `var_dump` each item            | `$stream->varDump()`    |
 
 Setup
 -----

--- a/README.md
+++ b/README.md
@@ -1747,6 +1747,83 @@ $result = Stream::of($iterable)
 // 15
 ```
 
+### Print
+Print each item in the stream.
+
+```$stream->print(string|null $glue): void```
+
+```php
+use IterTools\Stream;
+
+$input = [1, 2, 3, 4, 5];
+
+Stream::of($iterable)->print('; ');
+// '1; 2; 3; 4; 5'
+```
+
+### Print Ln
+Print each item in the stream on a new line.
+
+```$stream->printLn(): void```
+
+```php
+use IterTools\Stream;
+
+$input = [1, 2, 3];
+
+Stream::of($iterable)->printLn();
+/*
+1
+2
+3
+*/
+```
+
+### Print R
+Calls `print_r()` function for each item in the stream.
+
+```$stream->printR(): void```
+
+```php
+use IterTools\Stream;
+
+$input = [['id' => 1], ['id' => 2], ['id' => 3]];
+
+Stream::of($iterable)->printR();
+/*
+Array
+(
+    [id] => 1
+)
+Array
+(
+    [id] => 2
+)
+Array
+(
+    [id] => 3
+)
+*/
+```
+
+### Var Dump
+Calls `var_dump()` function for each item in the stream.
+
+```$stream->varDump(): void```
+
+```php
+use IterTools\Stream;
+
+$input = [1, 2, 3];
+
+Stream::of($iterable)->varDump();
+/*
+int(1)
+int(2)
+int(3)
+*/
+```
+
 ## Composition
 IterTools can be combined to create new iterable compositions.
 #### Zip Strings

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -677,11 +677,21 @@ class Stream implements \IteratorAggregate
     /**
      * Print each item in the stream
      *
+     * @param string|null $glue
+     *
      * @return void
      */
-    public function print(): void
+    public function print(?string $glue = null): void
     {
+        $isFirstIteration = true;
+
         foreach ($this->iterable as $item) {
+            if ($isFirstIteration) {
+                $isFirstIteration = false;
+            } elseif ($glue !== null) {
+                print($glue);
+            }
+
             // @phpstan-ignore-next-line
             print($item);
         }

--- a/tests/Stream/PrintTest.php
+++ b/tests/Stream/PrintTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace IterTools\Tests\Stream;
 
 use IterTools\Stream;
-use IterTools\Tests\Fixture;
 use IterTools\Tests\Fixture\ArrayIteratorFixture;
 use IterTools\Tests\Fixture\GeneratorFixture;
 use IterTools\Tests\Fixture\IteratorAggregateFixture;
@@ -19,7 +18,7 @@ class PrintTest extends \PHPUnit\Framework\TestCase
      * @dataProvider dataProviderForPrintIterator
      * @dataProvider dataProviderForPrintTraversable
      */
-    public function testPrint(iterable $data, string $expectedOutput): void
+    public function testPrint(iterable $data, ?string $glue, string $expectedOutput): void
     {
         // Given
         $stream = Stream::of($data);
@@ -28,7 +27,7 @@ class PrintTest extends \PHPUnit\Framework\TestCase
         $this->expectOutputString($expectedOutput);
 
         // When
-        $stream->print();
+        $stream->print($glue);
     }
 
     public function dataProviderForPrintArray(): array
@@ -36,23 +35,53 @@ class PrintTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 [],
+                null,
+                '',
+            ],
+            [
+                [],
+                ', ',
                 '',
             ],
             [
                 [1],
+                null,
+                '1',
+            ],
+            [
+                [1],
+                ', ',
                 '1',
             ],
             [
                 [1, 2, 3],
+                null,
                 '123',
             ],
             [
+                [1, 2, 3],
+                ', ',
+                '1, 2, 3',
+            ],
+            [
                 ['first', 'second', 'third'],
+                null,
                 'firstsecondthird',
             ],
             [
+                ['first', 'second', 'third'],
+                ', ',
+                'first, second, third',
+            ],
+            [
                 ['日本語', 'English', 'Español'],
+                null,
                 '日本語EnglishEspañol',
+            ],
+            [
+                ['日本語', 'English', 'Español'],
+                ', ',
+                '日本語, English, Español',
             ],
         ];
     }
@@ -64,23 +93,53 @@ class PrintTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $gen([]),
+                null,
+                '',
+            ],
+            [
+                $gen([]),
+                ', ',
                 '',
             ],
             [
                 $gen([1]),
+                null,
+                '1',
+            ],
+            [
+                $gen([1]),
+                ', ',
                 '1',
             ],
             [
                 $gen([1, 2, 3]),
+                null,
                 '123',
             ],
             [
+                $gen([1, 2, 3]),
+                ', ',
+                '1, 2, 3',
+            ],
+            [
                 $gen(['first', 'second', 'third']),
+                null,
                 'firstsecondthird',
             ],
             [
+                $gen(['first', 'second', 'third']),
+                ', ',
+                'first, second, third',
+            ],
+            [
                 $gen(['日本語', 'English', 'Español']),
+                null,
                 '日本語EnglishEspañol',
+            ],
+            [
+                $gen(['日本語', 'English', 'Español']),
+                ', ',
+                '日本語, English, Español',
             ],
         ];
     }
@@ -92,23 +151,53 @@ class PrintTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $iter([]),
+                null,
+                '',
+            ],
+            [
+                $iter([]),
+                ', ',
                 '',
             ],
             [
                 $iter([1]),
+                null,
+                '1',
+            ],
+            [
+                $iter([1]),
+                ', ',
                 '1',
             ],
             [
                 $iter([1, 2, 3]),
+                null,
                 '123',
             ],
             [
+                $iter([1, 2, 3]),
+                ', ',
+                '1, 2, 3',
+            ],
+            [
                 $iter(['first', 'second', 'third']),
+                null,
                 'firstsecondthird',
             ],
             [
+                $iter(['first', 'second', 'third']),
+                ', ',
+                'first, second, third',
+            ],
+            [
                 $iter(['日本語', 'English', 'Español']),
+                null,
                 '日本語EnglishEspañol',
+            ],
+            [
+                $iter(['日本語', 'English', 'Español']),
+                ', ',
+                '日本語, English, Español',
             ],
         ];
     }
@@ -120,23 +209,53 @@ class PrintTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $trav([]),
+                null,
+                '',
+            ],
+            [
+                $trav([]),
+                ', ',
                 '',
             ],
             [
                 $trav([1]),
+                null,
+                '1',
+            ],
+            [
+                $trav([1]),
+                ', ',
                 '1',
             ],
             [
                 $trav([1, 2, 3]),
+                null,
                 '123',
             ],
             [
+                $trav([1, 2, 3]),
+                ', ',
+                '1, 2, 3',
+            ],
+            [
                 $trav(['first', 'second', 'third']),
+                null,
                 'firstsecondthird',
             ],
             [
+                $trav(['first', 'second', 'third']),
+                ', ',
+                'first, second, third',
+            ],
+            [
                 $trav(['日本語', 'English', 'Español']),
+                null,
                 '日本語EnglishEspañol',
+            ],
+            [
+                $trav(['日本語', 'English', 'Español']),
+                ', ',
+                '日本語, English, Español',
             ],
         ];
     }


### PR DESCRIPTION
`Stream::print()`: `$glue` param added.

I think there is a common task to print collections with glue (e. g. `, `).

Since this branch starts from `single_chunkwise` this PR makes sense to merge after the merge of [previous PR](https://github.com/markrogoyski/itertools-php/pull/10).

Sorry for this confusion.