### PR TITLE
Method Reduce::toVectorLength() added

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,17 @@ Quick Reference
 | [`sameCount`](#Same-Count)   | True if iterables have the same lengths                 | `Summary::sameCount(...$iterables)`        |
 
 #### Reduce
-| Reducer                    | Description                             | Code Snippet                                                  |
-|----------------------------|-----------------------------------------|---------------------------------------------------------------|
-| [`toAverage`](#To-Average) | Mean average of elements                | `Reduce::toAverage($numbers)`                                 |
-| [`toCount`](#To-Count)     | Reduce to length of iterable            | `Reduce::toCount($data)`                                      |
-| [`toMax`](#To-Max)         | Reduce to its largest element           | `Reduce::toMax($numbers)`                                     |
-| [`toMin`](#To-Min)         | Reduce to its smallest element          | `Reduce::toMin($numbers)`                                     |
-| [`toProduct`](#To-Product) | Reduce to the product of its elements   | `Reduce::toProduct($numbers)`                                 |
-| [`toString`](#To-String)   | Reduce to joined string                 | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
-| [`toSum`](#To-Sum)         | Reduce to the sum of its elements       | `Reduce::toSum($numbers)`                                     |
-| [`toValue`](#To-Value)     | Reduce to value using callable reducer  | `Reduce::toValue($data, $reducer, $initialValue)`             |
+| Reducer                               | Description                                   | Code Snippet                                                  |
+|---------------------------------------|-----------------------------------------------|---------------------------------------------------------------|
+| [`toAverage`](#To-Average)            | Mean average of elements                      | `Reduce::toAverage($numbers)`                                 |
+| [`toCount`](#To-Count)                | Reduce to length of iterable                  | `Reduce::toCount($data)`                                      |
+| [`toMax`](#To-Max)                    | Reduce to its largest element                 | `Reduce::toMax($numbers)`                                     |
+| [`toMin`](#To-Min)                    | Reduce to its smallest element                | `Reduce::toMin($numbers)`                                     |
+| [`toProduct`](#To-Product)            | Reduce to the product of its elements         | `Reduce::toProduct($numbers)`                                 |
+| [`toString`](#To-String)              | Reduce to joined string                       | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
+| [`toSum`](#To-Sum)                    | Reduce to the sum of its elements             | `Reduce::toSum($numbers)`                                     |
+| [`toVectorLength`](#To-Vector-Length) | Reduces given collection to the vector length | `Reduce::toVectorLength($vector)`                             |
+| [`toValue`](#To-Value)                | Reduce to value using callable reducer        | `Reduce::toValue($data, $reducer, $initialValue)`             |
 
 ### Stream Iteration Tools
 #### Stream Sources
@@ -131,16 +132,17 @@ Quick Reference
 | [`sameCountWith`](#Same-Count-With)          | Returns true if stream and all given collections have the same lengths           | `$stream->sameCountWith(...$iterables)`      |
 
 ##### Reduction Terminal Operations
-| Terminal Operation                           | Description                                                                      | Code Snippet                                             |
-|----------------------------------------------|----------------------------------------------------------------------------------|----------------------------------------------------------|
-| [`toAverage`](#To-Average-1)                 | Reduces stream to the mean average of its items                                  | `$stream->toAverage()`                                   |
-| [`toCount`](#To-Count-1)                     | Reduces stream to its length                                                     | `$stream->toCount()`                                     |
-| [`toMax`](#To-Max-1)                         | Reduces stream to its max value                                                  | `$stream->toMax()`                                       |
-| [`toMin`](#To-Min-1)                         | Reduces stream to its min value                                                  | `$stream->toMin()`                                       |
-| [`toProduct`](#To-Product-1)                 | Reduces stream to the product of its items                                       | `$stream->toProduct()`                                   |
-| [`toString`](#To-String-1)                   | Reduces stream to joined string                                                  | `$stream->toString([$separator], [$prefix], [$suffix])`  |
-| [`toSum`](#To-Sum-1)                         | Reduces stream to the sum of its items                                           | `$stream->toSum()`                                       |
-| [`toValue`](#To-Value-1)                     | Reduces stream like array_reduce() function                                      | `$stream->toValue($reducer, $initialValue)`              |
+| Terminal Operation                        | Description                                       | Code Snippet                                            |
+|-------------------------------------------|---------------------------------------------------|---------------------------------------------------------|
+| [`toAverage`](#To-Average-1)              | Reduces stream to the mean average of its items   | `$stream->toAverage()`                                  |
+| [`toCount`](#To-Count-1)                  | Reduces stream to its length                      | `$stream->toCount()`                                    |
+| [`toMax`](#To-Max-1)                      | Reduces stream to its max value                   | `$stream->toMax()`                                      |
+| [`toMin`](#To-Min-1)                      | Reduces stream to its min value                   | `$stream->toMin()`                                      |
+| [`toProduct`](#To-Product-1)              | Reduces stream to the product of its items        | `$stream->toProduct()`                                  |
+| [`toString`](#To-String-1)                | Reduces stream to joined string                   | `$stream->toString([$separator], [$prefix], [$suffix])` |
+| [`toSum`](#To-Sum-1)                      | Reduces stream to the sum of its items            | `$stream->toSum()`                                      |
+| [`toVectorLength`](#To-Vector-Length-1)   | Reduces stream to the vector length               | `$stream->toVectorLength($vector)`                      |
+| [`toValue`](#To-Value-1)                  | Reduces stream like array_reduce() function       | `$stream->toValue($reducer, $initialValue)`             |
 
 ##### Side Effect Terminal Operations
 | Terminal Operation         | Description                     | Code Snippet                                          |
@@ -1010,6 +1012,22 @@ $sum = Reduce::toSum($parts);
 // 60
 ```
 
+### To Vector Length
+Reduces given collection to the vector length using items as coordinates.
+
+```Reduce::toVectorLength(iterable $vector): float```
+
+Returns 0 if given collection is empty.
+
+```php
+use IterTools\Reduce;
+
+$vector = [3, 4];
+
+$length = Reduce::toVectorLength($vector);
+// 5
+```
+
 ### To Value
 Reduce elements to a single value using reducer function.
 
@@ -1776,6 +1794,23 @@ $input = [1, 2, 3, 4, 5];
 $result = Stream::of($iterable)
     ->toSum();
 // 15
+```
+
+### To Vector Length
+Reduces iterable source to the vector length using items as coordinates.
+
+```$stream->toVectorLength(iterable $vector): float```
+
+Returns 0 if given collection is empty.
+
+```php
+use IterTools\Reduce;
+
+$vector = [3, 4];
+
+$length = Stream::of($iterable)
+    ->toVectorLength($vector);
+// 5
 ```
 
 ### To Value

--- a/src/Reduce.php
+++ b/src/Reduce.php
@@ -154,4 +154,22 @@ class Reduce
         $joined = \implode($separator, $items);
         return $prefix . $joined . $suffix;
     }
+
+    /**
+     * Reduces given collection to the vector length using items as coordinates.
+     *
+     * Returns 0 if given collection is empty.
+     *
+     * @param iterable<numeric> $vector
+     *
+     * @return float
+     */
+    public static function toVectorLength(iterable $vector): float
+    {
+        $result = 0;
+        foreach ($vector as $coordinate) {
+            $result += $coordinate**2;
+        }
+        return sqrt($result);
+    }
 }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -675,6 +675,22 @@ class Stream implements \IteratorAggregate
     }
 
     /**
+     * Reduces iterable to the vector length using items as coordinates.
+     *
+     * Returns 0 if given collection is empty.
+     *
+     * @return float
+     *
+     * @see Reduce::toVectorLength()
+     */
+    public function toVectorLength(): float
+    {
+        /** @var iterable<numeric> $iterable */
+        $iterable = $this->iterable;
+        return Reduce::toVectorLength($iterable);
+    }
+
+    /**
      * Reduces iterable source like array_reduce() function.
      *
      * But unlike array_reduce(), it works with all iterable types.

--- a/tests/Reduce/ToVectorLengthTest.php
+++ b/tests/Reduce/ToVectorLengthTest.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IterTools\Tests\Reduce;
+
+use IterTools\Reduce;
+use IterTools\Tests\Fixture\ArrayIteratorFixture;
+use IterTools\Tests\Fixture\GeneratorFixture;
+use IterTools\Tests\Fixture\IteratorAggregateFixture;
+
+class ToVectorLengthTest extends \PHPUnit\Framework\TestCase
+{
+    protected const ROUND_PRECISION = 0.0001;
+
+    /**
+     * @test         toVectorLength array
+     * @dataProvider dataProviderForArray
+     * @param        array $vector
+     * @param        int|float $expected
+     */
+    public function testArray(array $vector, $expected)
+    {
+        // When
+        $result = Reduce::toVectorLength($vector);
+
+        // Then
+        $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
+    }
+
+    public function dataProviderForArray(): array
+    {
+        return [
+            [
+                [],
+                0,
+            ],
+            [
+                [0],
+                0,
+            ],
+            [
+                [1],
+                1,
+            ],
+            [
+                [2],
+                2,
+            ],
+            [
+                [1, 1],
+                sqrt(2),
+            ],
+            [
+                [1, 1, 1],
+                sqrt(3),
+            ],
+            [
+                [1, 1, 1, 1],
+                2,
+            ],
+            [
+                [3, 4],
+                5,
+            ],
+            [
+                [1, 2, 3, 4],
+                sqrt(30),
+            ],
+            [
+                ['1', '2', '3', '4'],
+                sqrt(30),
+            ],
+            [
+                [1, 2, '3', '4'],
+                sqrt(30),
+            ],
+            [
+                [1.1, 2.2, 3.3, 4.4],
+                sqrt(36.3),
+            ],
+            [
+                ['1.1', '2.2', 3.3, 4.4],
+                sqrt(36.3),
+            ],
+            [
+                [1, 2, 3.3, 4.4],
+                sqrt(35.25),
+            ],
+            [
+                [1, '2', 3.3, '4.4'],
+                sqrt(35.25),
+            ],
+        ];
+    }
+
+    /**
+     * @test         toVectorLength generators
+     * @dataProvider dataProviderForGenerators
+     * @param        \Generator $vector
+     * @param        mixed $expected
+     */
+    public function testGenerators(\Generator $vector, $expected)
+    {
+        // When
+        $result = Reduce::toVectorLength($vector);
+
+        // Then
+        $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
+    }
+
+    public function dataProviderForGenerators(): array
+    {
+        $gen = static function (array $data) {
+            return GeneratorFixture::getGenerator($data);
+        };
+
+        return [
+            [
+                $gen([]),
+                0,
+            ],
+            [
+                $gen([0]),
+                0,
+            ],
+            [
+                $gen([1]),
+                1,
+            ],
+            [
+                $gen([2]),
+                2,
+            ],
+            [
+                $gen([1, 1]),
+                sqrt(2),
+            ],
+            [
+                $gen([1, 1, 1]),
+                sqrt(3),
+            ],
+            [
+                $gen([1, 1, 1, 1]),
+                2,
+            ],
+            [
+                $gen([3, 4]),
+                5,
+            ],
+            [
+                $gen([1, 2, 3, 4]),
+                sqrt(30),
+            ],
+            [
+                $gen(['1', '2', '3', '4']),
+                sqrt(30),
+            ],
+            [
+                $gen([1, 2, '3', '4']),
+                sqrt(30),
+            ],
+            [
+                $gen([1.1, 2.2, 3.3, 4.4]),
+                sqrt(36.3),
+            ],
+            [
+                $gen(['1.1', '2.2', 3.3, 4.4]),
+                sqrt(36.3),
+            ],
+            [
+                $gen([1, 2, 3.3, 4.4]),
+                sqrt(35.25),
+            ],
+            [
+                $gen([1, '2', 3.3, '4.4']),
+                sqrt(35.25),
+            ],
+        ];
+    }
+
+    /**
+     * @test         toVectorLength iterators
+     * @dataProvider dataProviderForIterators
+     * @param        \Generator $vector
+     * @param        mixed $expected
+     */
+    public function testIterators(\Iterator $vector, $expected)
+    {
+        // When
+        $result = Reduce::toVectorLength($vector);
+
+        // Then
+        $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
+    }
+
+    public function dataProviderForIterators(): array
+    {
+        $iter = static function (array $data) {
+            return new ArrayIteratorFixture($data);
+        };
+
+        return [
+            [
+                $iter([]),
+                0,
+            ],
+            [
+                $iter([0]),
+                0,
+            ],
+            [
+                $iter([1]),
+                1,
+            ],
+            [
+                $iter([2]),
+                2,
+            ],
+            [
+                $iter([1, 1]),
+                sqrt(2),
+            ],
+            [
+                $iter([1, 1, 1]),
+                sqrt(3),
+            ],
+            [
+                $iter([1, 1, 1, 1]),
+                2,
+            ],
+            [
+                $iter([3, 4]),
+                5,
+            ],
+            [
+                $iter([1, 2, 3, 4]),
+                sqrt(30),
+            ],
+            [
+                $iter(['1', '2', '3', '4']),
+                sqrt(30),
+            ],
+            [
+                $iter([1, 2, '3', '4']),
+                sqrt(30),
+            ],
+            [
+                $iter([1.1, 2.2, 3.3, 4.4]),
+                sqrt(36.3),
+            ],
+            [
+                $iter(['1.1', '2.2', 3.3, 4.4]),
+                sqrt(36.3),
+            ],
+            [
+                $iter([1, 2, 3.3, 4.4]),
+                sqrt(35.25),
+            ],
+            [
+                $iter([1, '2', 3.3, '4.4']),
+                sqrt(35.25),
+            ],
+        ];
+    }
+
+    /**
+     * @test         toVectorLength traversables
+     * @dataProvider dataProviderForTraversables
+     * @param        \Traversable $vector
+     * @param        mixed $expected
+     */
+    public function testTraversables(\Traversable $vector, $expected)
+    {
+        // When
+        $result = Reduce::toVectorLength($vector);
+
+        // Then
+        $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
+    }
+
+    public function dataProviderForTraversables(): array
+    {
+        $trav = static function (array $data) {
+            return new IteratorAggregateFixture($data);
+        };
+
+        return [
+            [
+                $trav([]),
+                0,
+            ],
+            [
+                $trav([0]),
+                0,
+            ],
+            [
+                $trav([1]),
+                1,
+            ],
+            [
+                $trav([2]),
+                2,
+            ],
+            [
+                $trav([1, 1]),
+                sqrt(2),
+            ],
+            [
+                $trav([1, 1, 1]),
+                sqrt(3),
+            ],
+            [
+                $trav([1, 1, 1, 1]),
+                2,
+            ],
+            [
+                $trav([3, 4]),
+                5,
+            ],
+            [
+                $trav([1, 2, 3, 4]),
+                sqrt(30),
+            ],
+            [
+                $trav(['1', '2', '3', '4']),
+                sqrt(30),
+            ],
+            [
+                $trav([1, 2, '3', '4']),
+                sqrt(30),
+            ],
+            [
+                $trav([1.1, 2.2, 3.3, 4.4]),
+                sqrt(36.3),
+            ],
+            [
+                $trav(['1.1', '2.2', 3.3, 4.4]),
+                sqrt(36.3),
+            ],
+            [
+                $trav([1, 2, 3.3, 4.4]),
+                sqrt(35.25),
+            ],
+            [
+                $trav([1, '2', 3.3, '4.4']),
+                sqrt(35.25),
+            ],
+        ];
+    }
+}

--- a/tests/Stream/ReduceTest.php
+++ b/tests/Stream/ReduceTest.php
@@ -517,6 +517,20 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->toString(),
                 '',
             ],
+            [
+                [1, 2],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toVectorLength(),
+                sqrt(0),
+            ],
+            [
+                [1, 2],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([3, 4])
+                    ->toVectorLength(),
+                sqrt(30),
+            ],
         ];
     }
 
@@ -951,6 +965,20 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->zipEqualWith([1, 2, 3, 4, 5, 6, 7, 8, 9])
                     ->toValue(fn ($carry, $item) => $carry + array_sum($item)),
                 90,
+            ],
+            [
+                $gen([1, 2]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toVectorLength(),
+                sqrt(0),
+            ],
+            [
+                $gen([1, 2]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([3, 4])
+                    ->toVectorLength(),
+                sqrt(30),
             ],
         ];
     }
@@ -1387,6 +1415,20 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->toValue(fn ($carry, $item) => $carry + array_sum($item)),
                 90,
             ],
+            [
+                $iter([1, 2]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toVectorLength(),
+                sqrt(0),
+            ],
+            [
+                $iter([1, 2]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([3, 4])
+                    ->toVectorLength(),
+                sqrt(30),
+            ],
         ];
     }
 
@@ -1821,6 +1863,20 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->zipEqualWith([1, 2, 3, 4, 5, 6, 7, 8, 9])
                     ->toValue(fn ($carry, $item) => $carry + array_sum($item)),
                 90,
+            ],
+            [
+                $trav([1, 2]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toVectorLength(),
+                sqrt(0),
+            ],
+            [
+                $trav([1, 2]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([3, 4])
+                    ->toVectorLength(),
+                sqrt(30),
             ],
         ];
     }


### PR DESCRIPTION
1. Methods `Reduce::toVectorLength()` and `Stream::toVectorLength()` added.
2. Tests added for new methods.
3. README updated with description of new methods.