### PR TITLE
Fix of tests: str_starts_with() usages removed

### DIFF
--- a/tests/Util/UniqueExtractorTest.php
+++ b/tests/Util/UniqueExtractorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace IterTools\Tests\Set;
+namespace IterTools\Tests\Util;
 
 use IterTools\Util\UniqueExtractor;
 use IterTools\Tests\Fixture;
@@ -20,7 +20,7 @@ class UniqueExtractorTest extends \PHPUnit\Framework\TestCase
         $string = UniqueExtractor::getString($var, true);
 
         // Then
-        $this->assertTrue(str_starts_with($string, $expectedPrefix), "got: $string");
+        $this->assertTrue($this->startsWith($string, $expectedPrefix), "got: $string");
     }
 
     public function dataProviderForStrict(): array
@@ -112,7 +112,7 @@ class UniqueExtractorTest extends \PHPUnit\Framework\TestCase
         $string = UniqueExtractor::getString($var, false);
 
         // Then
-        $this->assertTrue(str_starts_with($string, $expectedPrefix), "got: $string");
+        $this->assertTrue($this->startsWith($string, $expectedPrefix), "got: $string");
     }
 
     public function dataProviderForNotStrict(): array
@@ -191,5 +191,10 @@ class UniqueExtractorTest extends \PHPUnit\Framework\TestCase
                 'boolean_0'
             ],
         ];
+    }
+
+    protected function startsWith($string, $startString): bool
+    {
+        return (substr($string, 0, strlen($startString)) === $startString);
     }
 }


### PR DESCRIPTION
Function [`str_starts_with()`](https://www.php.net/manual/ru/function.str-starts-with.php) usages are replaced by custom method `startsWith()` (`str_starts_with()` requires PHP 8.0, using polifill is not safe).
