### PR TITLE
Optional comparator parameter added to `toMin()`, `toMax()`, `toMinMax()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,31 @@
   * `compressAssociative`
   * `reindex`
   * `filterKeys`
+  * `sort`
+* Reduce
+  * `toFirst`
+  * `toLast`
+  * `toFirstAndLast`
+  * `toMin` (parameter `$compareBy` added)
+  * `toMax` (parameter `$compareBy` added)
+  * `toMinMax` (parameter `$compareBy` added)
 * Stream
   * Source
     * `ofRange`
     * `ofFileLines`
     * `ofCsvFile`
-  * Operations
+  * Stream Operations
     * `compressAssociative`
     * `reindex`
     * `filterKeys`
+    * `sort`
+  * Reduction Terminal Operations
+    * `toFirst`
+    * `toLast`
+    * `toFirstAndLast`
+    * `toMin` (parameter `$compareBy` added)
+    * `toMax` (parameter `$compareBy` added)
+    * `toMinMax` (parameter `$compareBy` added)
   * Transformation Terminal Operations
     * `toAssociativeArray`
   * File Terminal Operations

--- a/README.md
+++ b/README.md
@@ -55,24 +55,25 @@ Quick Reference
 | [`zipLongest`](#ZipLongest) | Iterate multiple collections simultaneously until the longest iterator completes        | `Multi::zipLongest($list1, $list2)` |
 
 #### Single Iteration
-| Iterator                                       | Description                                         | Code Snippet                                                |
-|------------------------------------------------|-----------------------------------------------------|-------------------------------------------------------------|
-| [`chunkwise`](#Chunkwise)                      | Iterate by chunks                                   | `Single::chunkwise($data, $chunkSize)`                      |
-| [`chunkwiseOverlap`](#Chunkwise-Overlap)       | Iterate by overlapped chunks                        | `Single::chunkwiseOverlap($data, $chunkSize, $overlapSize)` |
-| [`compress`](#Compress)                        | Filter out elements not selected                    | `Single::compress($data, $selectors)`                       |
-| [`compressAssociative`](#Compress-Associative) | Filter out elements by keys not selected            | `Single::compressAssociative($data, $selectorKeys)`         |
-| [`dropWhile`](#Drop-While)                     | Drop elements while predicate is true               | `Single::dropWhile($data, $predicate)`                      |
-| [`filterTrue`](#Filter-True)                   | Filter for elements where predicate is true         | `Single::filterTrue($data, $predicate)`                     |
-| [`filterFalse`](#Filter-False)                 | Filter for elements where predicate is false        | `Single::filterFalse($data, $predicate)`                    |
-| [`filterKeys`](#Filter-Keys)                   | Filter for keys where predicate is true             | `Single::filterKeys($data, $predicate)`                     |
-| [`groupBy`](#Group-By)                         | Group data by a common element                      | `Single::groupBy($data, $groupKeyFunction)`                 |
-| [`limit`](#Limit)                              | Iterate up to a limit                               | `Single::limit($data, $limit)`                              |
-| [`map`](#Map)                                  | Map function onto each item                         | `Single::map($data, $function)`                             |
-| [`pairwise`](#Pairwise)                        | Iterate successive overlapping pairs                | `Single::pairwise($data)`                                   |
-| [`reindex`](#Reindex)                          | Reindex keys of key-value iterable                  | `Single::reindex($data, $reindexer)`                        |
-| [`repeat`](#Repeat)                            | Repeat an item                                      | `Single::repeat($item, $repetitions)`                       |
-| [`string`](#String)                            | Iterate the characters of a string                  | `Single::string($string)`                                   |
-| [`takeWhile`](#Take-While)                     | Iterate elements while predicate is true            | `Single::takeWhile($data, $predicate)`                      |
+| Iterator                                       | Description                                  | Code Snippet                                                |
+|------------------------------------------------|----------------------------------------------|-------------------------------------------------------------|
+| [`chunkwise`](#Chunkwise)                      | Iterate by chunks                            | `Single::chunkwise($data, $chunkSize)`                      |
+| [`chunkwiseOverlap`](#Chunkwise-Overlap)       | Iterate by overlapped chunks                 | `Single::chunkwiseOverlap($data, $chunkSize, $overlapSize)` |
+| [`compress`](#Compress)                        | Filter out elements not selected             | `Single::compress($data, $selectors)`                       |
+| [`compressAssociative`](#Compress-Associative) | Filter out elements by keys not selected     | `Single::compressAssociative($data, $selectorKeys)`         |
+| [`dropWhile`](#Drop-While)                     | Drop elements while predicate is true        | `Single::dropWhile($data, $predicate)`                      |
+| [`filterTrue`](#Filter-True)                   | Filter for elements where predicate is true  | `Single::filterTrue($data, $predicate)`                     |
+| [`filterFalse`](#Filter-False)                 | Filter for elements where predicate is false | `Single::filterFalse($data, $predicate)`                    |
+| [`filterKeys`](#Filter-Keys)                   | Filter for keys where predicate is true      | `Single::filterKeys($data, $predicate)`                     |
+| [`groupBy`](#Group-By)                         | Group data by a common element               | `Single::groupBy($data, $groupKeyFunction)`                 |
+| [`limit`](#Limit)                              | Iterate up to a limit                        | `Single::limit($data, $limit)`                              |
+| [`map`](#Map)                                  | Map function onto each item                  | `Single::map($data, $function)`                             |
+| [`pairwise`](#Pairwise)                        | Iterate successive overlapping pairs         | `Single::pairwise($data)`                                   |
+| [`reindex`](#Reindex)                          | Reindex keys of key-value iterable           | `Single::reindex($data, $reindexer)`                        |
+| [`repeat`](#Repeat)                            | Repeat an item                               | `Single::repeat($item, $repetitions)`                       |
+| [`sort`](#Sort)                                | Sorts a collection                           | `Single::sort($data, [$comparator])`                        |
+| [`string`](#String)                            | Iterate the characters of a string           | `Single::string($string)`                                   |
+| [`takeWhile`](#Take-While)                     | Iterate elements while predicate is true     | `Single::takeWhile($data, $predicate)`                      |
 
 #### Infinite Iteration
 | Iterator                     | Description                | Code Snippet                     |
@@ -124,18 +125,21 @@ Quick Reference
 | [`sameCount`](#Same-Count)   | True if iterables have the same lengths                 | `Summary::sameCount(...$iterables)`        |
 
 #### Reduce
-| Reducer                      | Description                                   | Code Snippet                                                  |
-|------------------------------|-----------------------------------------------|---------------------------------------------------------------|
-| [`toAverage`](#To-Average)   | Mean average of elements                      | `Reduce::toAverage($numbers)`                                 |
-| [`toCount`](#To-Count)       | Reduce to length of iterable                  | `Reduce::toCount($data)`                                      |
-| [`toMax`](#To-Max)           | Reduce to its largest element                 | `Reduce::toMax($numbers, [$compareBy])`                       |
-| [`toMin`](#To-Min)           | Reduce to its smallest element                | `Reduce::toMin($numbers, [$compareBy])`                       |
-| [`toMinMax`](#To-Min-Max)    | Reduce to array of upper and lower bounds     | `Reduce::toMinMax($numbers, [$compareBy])`                    |
-| [`toProduct`](#To-Product)   | Reduce to the product of its elements         | `Reduce::toProduct($numbers)`                                 |
-| [`toRange`](#To-Range)       | Reduce to difference of max and min values    | `Reduce::toRange($numbers)`                                   |
-| [`toString`](#To-String)     | Reduce to joined string                       | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
-| [`toSum`](#To-Sum)           | Reduce to the sum of its elements             | `Reduce::toSum($numbers)`                                     |
-| [`toValue`](#To-Value)       | Reduce to value using callable reducer        | `Reduce::toValue($data, $reducer, $initialValue)`             |
+| Reducer                                | Description                                | Code Snippet                                                  |
+|----------------------------------------|--------------------------------------------|---------------------------------------------------------------|
+| [`toAverage`](#To-Average)             | Mean average of elements                   | `Reduce::toAverage($numbers)`                                 |
+| [`toCount`](#To-Count)                 | Reduce to length of iterable               | `Reduce::toCount($data)`                                      |
+| [`toFirst`](#To-First)                 | Reduce to its first value                  | `Reduce::toFirst()`                                           |
+| [`toFirstAndLast`](#To-First-And-Last) | Reduce to its first and last values        | `Reduce::toFirstAndLast()`                                    |
+| [`toLast`](#To-Last)                   | Reduce to its last value                   | `Reduce::toLast()`                                            |
+| [`toMax`](#To-Max)                     | Reduce to its largest element              | `Reduce::toMax($numbers, [$compareBy])`                       |
+| [`toMin`](#To-Min)                     | Reduce to its smallest element             | `Reduce::toMin($numbers, [$compareBy])`                       |
+| [`toMinMax`](#To-Min-Max)              | Reduce to array of upper and lower bounds  | `Reduce::toMinMax($numbers, [$compareBy])`                    |
+| [`toProduct`](#To-Product)             | Reduce to the product of its elements      | `Reduce::toProduct($numbers)`                                 |
+| [`toRange`](#To-Range)                 | Reduce to difference of max and min values | `Reduce::toRange($numbers)`                                   |
+| [`toString`](#To-String)               | Reduce to joined string                    | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
+| [`toSum`](#To-Sum)                     | Reduce to the sum of its elements          | `Reduce::toSum($numbers)`                                     |
+| [`toValue`](#To-Value)                 | Reduce to value using callable reducer     | `Reduce::toValue($data, $reducer, $initialValue)`             |
 
 ### Stream Iteration Tools
 #### Stream Sources
@@ -179,6 +183,7 @@ Quick Reference
 | [`runningMin`](#Running-Min-1)                                            | Accumulate the running min over iterable source                                           | `$stream->runningMin($initialValue)`                                              |
 | [`runningProduct`](#Running-Product-1)                                    | Accumulate the running product over iterable source                                       | `$stream->runningProduct($initialValue)`                                          |
 | [`runningTotal`](#Running-Total-1)                                        | Accumulate the running total over iterable source                                         | `$stream->runningTotal($initialValue)`                                            |
+| [`sort`](#Sort-1)                                                         | Sorts the iterable source                                                                 | `$stream->sort([$comparator])`                                                    |
 | [`symmetricDifferenceWith`](#Symmetric-Difference-With)                   | Symmetric difference of iterable source and given iterables                               | `$this->symmetricDifferenceWith(...$iterables)`                                   |
 | [`symmetricDifference CoerciveWith`](#Symmetric-Difference-Coercive-With) | Symmetric difference of iterable source and given iterables with type coercion            | `$this->symmetricDifferenceCoerciveWith( ...$iterables)`                          |
 | [`takeWhile`](#Take-While-1)                                              | Return elements from the iterable source as long as the predicate is true                 | `$stream->takeWhile($predicate)`                                                  |
@@ -200,18 +205,21 @@ Quick Reference
 | [`sameCountWith`](#Same-Count-With)          | Returns true if stream and all given collections have the same lengths | `$stream->sameCountWith(...$iterables)`      |
 
 ##### Reduction Terminal Operations
-| Terminal Operation             | Description                                           | Code Snippet                                            |
-|--------------------------------|-------------------------------------------------------|---------------------------------------------------------|
-| [`toAverage`](#To-Average-1)   | Reduces stream to the mean average of its items       | `$stream->toAverage()`                                  |
-| [`toCount`](#To-Count-1)       | Reduces stream to its length                          | `$stream->toCount()`                                    |
-| [`toMax`](#To-Max-1)           | Reduces stream to its max value                       | `$stream->toMax([$compareBy])`                          |
-| [`toMin`](#To-Min-1)           | Reduces stream to its min value                       | `$stream->toMin([$compareBy])`                          |
-| [`toMinMax`](#To-Min-Max-1)    | Reduces stream to array of upper and lower bounds     | `$stream->toMinMax([$compareBy])`                       |
-| [`toProduct`](#To-Product-1)   | Reduces stream to the product of its items            | `$stream->toProduct()`                                  |
-| [`toString`](#To-String-1)     | Reduces stream to joined string                       | `$stream->toString([$separator], [$prefix], [$suffix])` |
-| [`toSum`](#To-Sum-1)           | Reduces stream to the sum of its items                | `$stream->toSum()`                                      |
-| [`toRange`](#To-Range-1)       | Reduces stream to difference of max and min values    | `$stream->toRange()`                                    |
-| [`toValue`](#To-Value-1)       | Reduces stream like array_reduce() function           | `$stream->toValue($reducer, $initialValue)`             |
+| Terminal Operation                       | Description                                        | Code Snippet                                            |
+|------------------------------------------|----------------------------------------------------|---------------------------------------------------------|
+| [`toAverage`](#To-Average-1)             | Reduces stream to the mean average of its items    | `$stream->toAverage()`                                  |
+| [`toCount`](#To-Count-1)                 | Reduces stream to its length                       | `$stream->toCount()`                                    |
+| [`toFirst`](#To-First-1)                 | Reduces stream to its first value                  | `$stream->toFirst()`                                    |
+| [`toFirstAndLast`](#To-First-And-Last-1) | Reduces stream to its first and last values        | `$stream->toFirstAndLast()`                             |
+| [`toLast`](#To-Last-1)                   | Reduces stream to its last value                   | `$stream->toLast()`                                     |
+| [`toMax`](#To-Max-1)                     | Reduces stream to its max value                    | `$stream->toMax([$compareBy])`                          |
+| [`toMin`](#To-Min-1)                     | Reduces stream to its min value                    | `$stream->toMin([$compareBy])`                          |
+| [`toMinMax`](#To-Min-Max-1)              | Reduces stream to array of upper and lower bounds  | `$stream->toMinMax([$compareBy])`                       |
+| [`toProduct`](#To-Product-1)             | Reduces stream to the product of its items         | `$stream->toProduct()`                                  |
+| [`toString`](#To-String-1)               | Reduces stream to joined string                    | `$stream->toString([$separator], [$prefix], [$suffix])` |
+| [`toSum`](#To-Sum-1)                     | Reduces stream to the sum of its items             | `$stream->toSum()`                                      |
+| [`toRange`](#To-Range-1)                 | Reduces stream to difference of max and min values | `$stream->toRange()`                                    |
+| [`toValue`](#To-Value-1)                 | Reduces stream like array_reduce() function        | `$stream->toValue($reducer, $initialValue)`             |
 
 ##### Transformation Terminal Operations
 | Terminal Operation                            | Description                                           | Code Snippet                                            |
@@ -706,6 +714,24 @@ foreach (Single::reindex($data, $reindexFunc) as $key => $filmData) {
 //         'year' => 1983,
 //     ],
 // ]
+```
+
+### Sort
+Sorts given collection.
+
+```Single::sort(iterable $data, callable $comparator = null)```
+
+If comparator is not proposed, the elements of given iterable must be comparable.
+
+```php
+use IterTools\Single;
+
+$data = [3, 4, 5, 9, 8, 7, 1, 6, 2];
+
+foreach (Single::sort($data) as $datum) {
+    print($datum);
+}
+// 1, 2, 3, 4, 5, 6, 7, 8, 9
 ```
 
 ### String
@@ -1357,10 +1383,58 @@ $length = Reduce::toCount($someIterable);
 // 3
 ```
 
+### To First
+Reduces iterable to its first element.
+
+```Reduce::toFirst(iterable $data): mixed```
+
+Throws `\LengthException` if collection is empty.
+
+```php
+use IterTools\Reduce;
+
+$input = [10, 20, 30];
+
+$result = Reduce::toFirst($input);
+// 10
+```
+
+### To First And Last
+Reduces iterable to its first and last elements.
+
+```Reduce::toFirstAndLast(iterable $data): array{mixed, mixed}```
+
+Throws `\LengthException` if collection is empty.
+
+```php
+use IterTools\Reduce;
+
+$input = [10, 20, 30];
+
+$result = Reduce::toFirstAndLast($input);
+// [10, 30]
+```
+
+### To Last
+Reduces iterable to its last element.
+
+```Reduce::toLast(iterable $data): mixed```
+
+Throws `\LengthException` if collection is empty.
+
+```php
+use IterTools\Reduce;
+
+$input = [10, 20, 30];
+
+$result = Reduce::toLast($input);
+// 30
+```
+
 ### To Max
 Reduces to the max value.
 
-```Reduce::toMax(iterable $data, callable|null $compareBy = null): mixed|null```
+```Reduce::toMax(iterable $data, callable $compareBy = null): mixed|null```
 
 - Callable param `$compareBy` must return comparable value.
 - If `$compareBy` is not proposed then items of given collection must be comparable.
@@ -1378,7 +1452,7 @@ $result = Reduce::toMax($numbers);
 ### To Min
 Reduces to the min value.
 
-```Reduce::toMin(iterable $data, callable|null $compareBy = null): mixed|null```
+```Reduce::toMin(iterable $data, callable $compareBy = null): mixed|null```
 
 - Callable param `$compareBy` must return comparable value.
 - If `$compareBy` is not proposed then items of given collection must be comparable.
@@ -1396,7 +1470,7 @@ $result = Reduce::toMin($numbers);
 ### To Min Max
 Reduces to array of its upper and lower bounds (max and min).
 
-```Reduce::toMinMax(iterable $numbers, callable|null $compareBy = null): array```
+```Reduce::toMinMax(iterable $numbers, callable $compareBy = null): array```
 
 - Callable param `$compareBy` must return comparable value.
 - If `$compareBy` is not proposed then items of given collection must be comparable.
@@ -2166,6 +2240,24 @@ $result = Stream::of($input)
 // 1, 3, 6, 10, 15
 ```
 
+### Sort
+Sorts the iterable source.
+
+```$stream->sort(callable $comparator = null)```
+
+If comparator is not proposed, the elements of the iterable source must be comparable.
+
+```php
+use IterTools\Stream;
+
+$input = [3, 4, 5, 9, 8, 7, 1, 6, 2];
+
+$result = Stream::of($input)
+    ->sort()
+    ->toArray();
+// 1, 2, 3, 4, 5, 6, 7, 8, 9
+```
+
 #### Symmetric difference With
 Return a stream of the symmetric difference of the stream and the given iterables.
 
@@ -2481,10 +2573,61 @@ $result = Stream::of($iterable)
 // 5
 ```
 
+### To First
+Reduces iterable source to its first element.
+
+```$stream->toFirst(): mixed```
+
+Throws `\LengthException` if iterable source is empty.
+
+```php
+use IterTools\Stream;
+
+$input = [10, 20, 30];
+
+$result = Stream::of($input)
+    ->toFirst();
+// 10
+```
+
+### To First And Last
+Reduces iterable source to its first and last elements.
+
+```$stream->toFirstAndLast(): array{mixed, mixed}```
+
+Throws `\LengthException` if iterable source is empty.
+
+```php
+use IterTools\Stream;
+
+$input = [10, 20, 30];
+
+$result = Stream::of($input)
+    ->toFirstAndLast();
+// [10, 30]
+```
+
+### To Last
+Reduces iterable source to its last element.
+
+```$stream->toLast(): mixed```
+
+Throws `\LengthException` if iterable source is empty.
+
+```php
+use IterTools\Stream;
+
+$input = [10, 20, 30];
+
+$result = Stream::of($input)
+    ->toLast();
+// 30
+```
+
 ##### To Max
 Reduces iterable source to its max value.
 
-```$stream->toMax(callable|null $compareBy = null): mixed```
+```$stream->toMax(callable $compareBy = null): mixed```
 
 Callable param `$compareBy` must return comparable value.
 
@@ -2505,7 +2648,7 @@ $result = Stream::of($iterable)
 ##### To Min
 Reduces iterable source to its min value.
 
-```$stream->toMin(callable|null $compareBy = null): mixed```
+```$stream->toMin(callable $compareBy = null): mixed```
 
 Callable param `$compareBy` must return comparable value.
 
@@ -2526,7 +2669,7 @@ $result = Stream::of($iterable)
 ##### To Min Max
 Reduces iterable source to array of its upper and lower bounds (max and min).
 
-```$stream->toMinMax(callable|null $compareBy = null): array```
+```$stream->toMinMax(callable $compareBy = null): array```
 
 Callable param `$compareBy` must return comparable value.
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Quick Reference
 |------------------------------|-----------------------------------------------|---------------------------------------------------------------|
 | [`toAverage`](#To-Average)   | Mean average of elements                      | `Reduce::toAverage($numbers)`                                 |
 | [`toCount`](#To-Count)       | Reduce to length of iterable                  | `Reduce::toCount($data)`                                      |
-| [`toMax`](#To-Max)           | Reduce to its largest element                 | `Reduce::toMax($numbers)`                                     |
-| [`toMin`](#To-Min)           | Reduce to its smallest element                | `Reduce::toMin($numbers)`                                     |
-| [`toMinMax`](#To-Min-Max)    | Reduce to array of upper and lower bounds     | `Reduce::toMinMax($numbers)`                                  |
+| [`toMax`](#To-Max)           | Reduce to its largest element                 | `Reduce::toMax($numbers, [$comparator])`                      |
+| [`toMin`](#To-Min)           | Reduce to its smallest element                | `Reduce::toMin($numbers, [$comparator])`                      |
+| [`toMinMax`](#To-Min-Max)    | Reduce to array of upper and lower bounds     | `Reduce::toMinMax($numbers, [$comparator])`                   |
 | [`toProduct`](#To-Product)   | Reduce to the product of its elements         | `Reduce::toProduct($numbers)`                                 |
 | [`toRange`](#To-Range)       | Reduce to difference of max and min values    | `Reduce::toRange($numbers)`                                   |
 | [`toString`](#To-String)     | Reduce to joined string                       | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
@@ -204,12 +204,12 @@ Quick Reference
 |--------------------------------|-------------------------------------------------------|---------------------------------------------------------|
 | [`toAverage`](#To-Average-1)   | Reduces stream to the mean average of its items       | `$stream->toAverage()`                                  |
 | [`toCount`](#To-Count-1)       | Reduces stream to its length                          | `$stream->toCount()`                                    |
-| [`toMax`](#To-Max-1)           | Reduces stream to its max value                       | `$stream->toMax()`                                      |
-| [`toMin`](#To-Min-1)           | Reduces stream to its min value                       | `$stream->toMin()`                                      |
+| [`toMax`](#To-Max-1)           | Reduces stream to its max value                       | `$stream->toMax([$comparator])`                         |
+| [`toMin`](#To-Min-1)           | Reduces stream to its min value                       | `$stream->toMin([$comparator])`                         |
+| [`toMinMax`](#To-Min-Max-1)    | Reduces stream to array of upper and lower bounds     | `$stream->toMinMax([$comparator])`                      |
 | [`toProduct`](#To-Product-1)   | Reduces stream to the product of its items            | `$stream->toProduct()`                                  |
 | [`toString`](#To-String-1)     | Reduces stream to joined string                       | `$stream->toString([$separator], [$prefix], [$suffix])` |
 | [`toSum`](#To-Sum-1)           | Reduces stream to the sum of its items                | `$stream->toSum()`                                      |
-| [`toMinMax`](#To-Min-Max-1)    | Reduces stream to array of upper and lower bounds     | `$stream->toMinMax()`                                   |
 | [`toRange`](#To-Range-1)       | Reduces stream to difference of max and min values    | `$stream->toRange()`                                    |
 | [`toValue`](#To-Value-1)       | Reduces stream like array_reduce() function           | `$stream->toValue($reducer, $initialValue)`             |
 
@@ -1360,10 +1360,10 @@ $length = Reduce::toCount($someIterable);
 ### To Max
 Reduces to the max value.
 
-- Elements must be comparable.
-- Returns null if collection is empty.
+```Reduce::toMax(iterable $data, callable|null $comparator = null): mixed|null```
 
-```Reduce::toMax(iterable $data): mixed|null```
+- If `$comparator` is `null` then elements must be comparable.
+- Returns null if collection is empty.
 
 ```php
 use IterTools\Reduce;
@@ -1377,10 +1377,10 @@ $result = Reduce::toMax($numbers);
 ### To Min
 Reduces to the min value.
 
-- Elements must be comparable.
-- Returns null if collection is empty.
+```Reduce::toMin(iterable $data, callable|null $comparator = null): mixed|null```
 
-```Reduce::toMin(iterable $data): mixed|null```
+- If `$comparator` is `null` then elements must be comparable.
+- Returns null if collection is empty.
 
 ```php
 use IterTools\Reduce;
@@ -1394,9 +1394,10 @@ $result = Reduce::toMin($numbers);
 ### To Min Max
 Reduces to array of its upper and lower bounds (max and min).
 
-```Reduce::toMinMax(iterable $numbers): array```
+```Reduce::toMinMax(iterable $numbers, callable|null $comparator = null): array```
 
-Returns `[null, null]` if given collection is empty.
+- If `$comparator` is `null` then elements must be comparable.
+- Returns `[null, null]` if given collection is empty.
 
 ```php
 use IterTools\Reduce;
@@ -2480,9 +2481,9 @@ $result = Stream::of($iterable)
 ##### To Max
 Reduces iterable source to its max value.
 
-```$stream->toMax(): mixed```
+```$stream->toMax(callable|null $comparator = null): mixed```
 
-Items of iterable source must be comparable.
+If `$comparator` is `null` then items of iterable source must be comparable.
 
 Returns null if iterable source is empty.
 
@@ -2499,9 +2500,9 @@ $result = Stream::of($iterable)
 ##### To Min
 Reduces iterable source to its min value.
 
-```$stream->toMin(): mixed```
+```$stream->toMin(callable|null $comparator = null): mixed```
 
-Items of iterable source must be comparable.
+If `$comparator` is `null` then items of iterable source must be comparable.
 
 Returns null if iterable source is empty.
 
@@ -2518,7 +2519,9 @@ $result = Stream::of($iterable)
 ##### To Min Max
 Reduces iterable source to array of its upper and lower bounds (max and min).
 
-```$stream->toMinMax(): array```
+```$stream->toMinMax(callable|null $comparator = null): array```
+
+If `$comparator` is `null` then items of iterable source must be comparable.
 
 Returns `[null, null]` if given collection is empty.
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Quick Reference
 |------------------------------|-----------------------------------------------|---------------------------------------------------------------|
 | [`toAverage`](#To-Average)   | Mean average of elements                      | `Reduce::toAverage($numbers)`                                 |
 | [`toCount`](#To-Count)       | Reduce to length of iterable                  | `Reduce::toCount($data)`                                      |
-| [`toMax`](#To-Max)           | Reduce to its largest element                 | `Reduce::toMax($numbers, [$comparator])`                      |
-| [`toMin`](#To-Min)           | Reduce to its smallest element                | `Reduce::toMin($numbers, [$comparator])`                      |
-| [`toMinMax`](#To-Min-Max)    | Reduce to array of upper and lower bounds     | `Reduce::toMinMax($numbers, [$comparator])`                   |
+| [`toMax`](#To-Max)           | Reduce to its largest element                 | `Reduce::toMax($numbers, [$compareBy])`                       |
+| [`toMin`](#To-Min)           | Reduce to its smallest element                | `Reduce::toMin($numbers, [$compareBy])`                       |
+| [`toMinMax`](#To-Min-Max)    | Reduce to array of upper and lower bounds     | `Reduce::toMinMax($numbers, [$compareBy])`                    |
 | [`toProduct`](#To-Product)   | Reduce to the product of its elements         | `Reduce::toProduct($numbers)`                                 |
 | [`toRange`](#To-Range)       | Reduce to difference of max and min values    | `Reduce::toRange($numbers)`                                   |
 | [`toString`](#To-String)     | Reduce to joined string                       | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
@@ -204,9 +204,9 @@ Quick Reference
 |--------------------------------|-------------------------------------------------------|---------------------------------------------------------|
 | [`toAverage`](#To-Average-1)   | Reduces stream to the mean average of its items       | `$stream->toAverage()`                                  |
 | [`toCount`](#To-Count-1)       | Reduces stream to its length                          | `$stream->toCount()`                                    |
-| [`toMax`](#To-Max-1)           | Reduces stream to its max value                       | `$stream->toMax([$comparator])`                         |
-| [`toMin`](#To-Min-1)           | Reduces stream to its min value                       | `$stream->toMin([$comparator])`                         |
-| [`toMinMax`](#To-Min-Max-1)    | Reduces stream to array of upper and lower bounds     | `$stream->toMinMax([$comparator])`                      |
+| [`toMax`](#To-Max-1)           | Reduces stream to its max value                       | `$stream->toMax([$compareBy])`                          |
+| [`toMin`](#To-Min-1)           | Reduces stream to its min value                       | `$stream->toMin([$compareBy])`                          |
+| [`toMinMax`](#To-Min-Max-1)    | Reduces stream to array of upper and lower bounds     | `$stream->toMinMax([$compareBy])`                       |
 | [`toProduct`](#To-Product-1)   | Reduces stream to the product of its items            | `$stream->toProduct()`                                  |
 | [`toString`](#To-String-1)     | Reduces stream to joined string                       | `$stream->toString([$separator], [$prefix], [$suffix])` |
 | [`toSum`](#To-Sum-1)           | Reduces stream to the sum of its items                | `$stream->toSum()`                                      |
@@ -1360,9 +1360,10 @@ $length = Reduce::toCount($someIterable);
 ### To Max
 Reduces to the max value.
 
-```Reduce::toMax(iterable $data, callable|null $comparator = null): mixed|null```
+```Reduce::toMax(iterable $data, callable|null $compareBy = null): mixed|null```
 
-- If `$comparator` is `null` then elements must be comparable.
+- Callable param `$compareBy` must return comparable value.
+- If `$compareBy` is not proposed then items of given collection must be comparable.
 - Returns null if collection is empty.
 
 ```php
@@ -1377,9 +1378,10 @@ $result = Reduce::toMax($numbers);
 ### To Min
 Reduces to the min value.
 
-```Reduce::toMin(iterable $data, callable|null $comparator = null): mixed|null```
+```Reduce::toMin(iterable $data, callable|null $compareBy = null): mixed|null```
 
-- If `$comparator` is `null` then elements must be comparable.
+- Callable param `$compareBy` must return comparable value.
+- If `$compareBy` is not proposed then items of given collection must be comparable.
 - Returns null if collection is empty.
 
 ```php
@@ -1394,9 +1396,10 @@ $result = Reduce::toMin($numbers);
 ### To Min Max
 Reduces to array of its upper and lower bounds (max and min).
 
-```Reduce::toMinMax(iterable $numbers, callable|null $comparator = null): array```
+```Reduce::toMinMax(iterable $numbers, callable|null $compareBy = null): array```
 
-- If `$comparator` is `null` then elements must be comparable.
+- Callable param `$compareBy` must return comparable value.
+- If `$compareBy` is not proposed then items of given collection must be comparable.
 - Returns `[null, null]` if given collection is empty.
 
 ```php
@@ -2481,9 +2484,11 @@ $result = Stream::of($iterable)
 ##### To Max
 Reduces iterable source to its max value.
 
-```$stream->toMax(callable|null $comparator = null): mixed```
+```$stream->toMax(callable|null $compareBy = null): mixed```
 
-If `$comparator` is `null` then items of iterable source must be comparable.
+Callable param `$compareBy` must return comparable value.
+
+If `$compareBy` is not proposed then items of iterable source must be comparable.
 
 Returns null if iterable source is empty.
 
@@ -2500,9 +2505,11 @@ $result = Stream::of($iterable)
 ##### To Min
 Reduces iterable source to its min value.
 
-```$stream->toMin(callable|null $comparator = null): mixed```
+```$stream->toMin(callable|null $compareBy = null): mixed```
 
-If `$comparator` is `null` then items of iterable source must be comparable.
+Callable param `$compareBy` must return comparable value.
+
+If `$compareBy` is not proposed then items of iterable source must be comparable.
 
 Returns null if iterable source is empty.
 
@@ -2519,9 +2526,11 @@ $result = Stream::of($iterable)
 ##### To Min Max
 Reduces iterable source to array of its upper and lower bounds (max and min).
 
-```$stream->toMinMax(callable|null $comparator = null): array```
+```$stream->toMinMax(callable|null $compareBy = null): array```
 
-If `$comparator` is `null` then items of iterable source must be comparable.
+Callable param `$compareBy` must return comparable value.
+
+If `$compareBy` is not proposed then items of iterable source must be comparable.
 
 Returns `[null, null]` if given collection is empty.
 

--- a/docs/README-RU.md
+++ b/docs/README-RU.md
@@ -65,6 +65,7 @@ $result = Stream::of([1, 1, 2, 2, 3, 4, 5])
 | [`map`](#Map)                            | Отображение коллекции с использованием callback-функции                   | `Single::map($data, $function)`                             |
 | [`pairwise`](#Pairwise)                  | Итерирует коллекцию попарно (с наложением)                                | `Single::pairwise($data)`                                   |
 | [`repeat`](#Repeat)                      | Повторяет данное значние заданное число раз                               | `Single::repeat($item, $repetitions)`                       |
+| [`sort`](#Sort)                          | Сортирует коллекцию                                                       | `Single::sort($data, [$comparator])`                        |
 | [`string`](#String)                      | Итерирует строку посимвольно                                              | `Single::string($string)`                                   |
 | [`takeWhile`](#Take-While)               | Отдает элементы, пока предикат возвращает истину                          | `Single::takeWhile($data, $predicate)`                      |
 
@@ -118,18 +119,21 @@ $result = Stream::of([1, 1, 2, 2, 3, 4, 5])
 | [`sameCount`](#Same-Count)   | Истинно, если данные коллекции имеют одинаковую длину                          | `Summary::sameCount(...$iterables)`        |
 
 #### Редуцирование
-| Метод                      | Описание                                                                            | Пример кода                                                   |
-|----------------------------|-------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| [`toAverage`](#To-Average) | Среднее арифметическое элементов коллекции                                          | `Reduce::toAverage($numbers)`                                 |
-| [`toCount`](#To-Count)     | Длина коллекции                                                                     | `Reduce::toCount($data)`                                      |
-| [`toMax`](#To-Max)         | Максимальный элемент коллекции                                                      | `Reduce::toMax($numbers, [$compareBy])`                       |
-| [`toMin`](#To-Min)         | Минимальный элемент коллекции                                                       | `Reduce::toMin($numbers, [$compareBy])`                       |
-| [`toMinMax`](#To-Min-Max)  | Минимальный и максимальный элемент коллекции                                        | `Reduce::toMinMax($numbers, [$compareBy])`                    |
-| [`toProduct`](#To-Product) | Произведение элементов коллекции                                                    | `Reduce::toProduct($numbers)`                                 |
-| [`toRange`](#To-Range)     | Разница между максимальным и минимальным элементами коллекции                       | `Reduce::toRange($numbers)`                                   |
-| [`toString`](#To-String)   | Преобразование коллекции в строку                                                   | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
-| [`toSum`](#To-Sum)         | Сумма элементов коллекции                                                           | `Reduce::toSum($numbers)`                                     |
-| [`toValue`](#To-Value)     | Редуцирование коллекции до значения, вычисляемого с использованием callback-функции | `Reduce::toValue($data, $reducer, $initialValue)`             |
+| Метод                                  | Описание                                                                            | Пример кода                                                   |
+|----------------------------------------|-------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| [`toAverage`](#To-Average)             | Среднее арифметическое элементов коллекции                                          | `Reduce::toAverage($numbers)`                                 |
+| [`toCount`](#To-Count)                 | Длина коллекции                                                                     | `Reduce::toCount($data)`                                      |
+| [`toFirst`](#To-First)                 | Первый элемент коллекции                                                            | `Reduce::toFirst()`                                           |
+| [`toFirstAndLast`](#To-First-And-Last) | Первый и последни элементы коллекции                                                | `Reduce::toFirstAndLast()`                                    |
+| [`toLast`](#To-Last)                   | Последний элемент коллекции                                                         | `Reduce::toLast()`                                            |
+| [`toMax`](#To-Max)                     | Максимальный элемент коллекции                                                      | `Reduce::toMax($numbers, [$compareBy])`                       |
+| [`toMin`](#To-Min)                     | Минимальный элемент коллекции                                                       | `Reduce::toMin($numbers, [$compareBy])`                       |
+| [`toMinMax`](#To-Min-Max)              | Минимальный и максимальный элемент коллекции                                        | `Reduce::toMinMax($numbers, [$compareBy])`                    |
+| [`toProduct`](#To-Product)             | Произведение элементов коллекции                                                    | `Reduce::toProduct($numbers)`                                 |
+| [`toRange`](#To-Range)                 | Разница между максимальным и минимальным элементами коллекции                       | `Reduce::toRange($numbers)`                                   |
+| [`toString`](#To-String)               | Преобразование коллекции в строку                                                   | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
+| [`toSum`](#To-Sum)                     | Сумма элементов коллекции                                                           | `Reduce::toSum($numbers)`                                     |
+| [`toValue`](#To-Value)                 | Редуцирование коллекции до значения, вычисляемого с использованием callback-функции | `Reduce::toValue($data, $reducer, $initialValue)`             |
 
 ### Цепочечный вызов итераторов
 #### Фабричные методы
@@ -169,6 +173,7 @@ $result = Stream::of([1, 1, 2, 2, 3, 4, 5])
 | [`runningMin`](#Running-Min-1)                                            | Поиск минимального значения из коллекции                                                                     | `$stream->runningMin($initialValue)`                                              |
 | [`runningProduct`](#Running-Product-1)                                    | Накопление произведения элементов коллекции                                                                  | `$stream->runningProduct($initialValue)`                                          |
 | [`runningTotal`](#Running-Total-1)                                        | Накопление суммы элементов коллекции                                                                         | `$stream->runningTotal($initialValue)`                                            |
+| [`sort`](#Sort-1)                                                         | Сортирует хранимую коллекцию                                                                                 | `$stream->sort([$comparator])`                                                    |
 | [`symmetricDifferenceWith`](#Symmetric-Difference-With)                   | Возвращает симметрическую разность хранимой коллекции с другими коллекциями                                  | `$this->symmetricDifferenceWith(...$iterables)`                                   |
 | [`symmetricDifference CoerciveWith`](#Symmetric-Difference-Coercive-With) | Возвращает симметрическую разность хранимой коллекции с другими коллекциями (в режиме приведения типов)      | `$this->symmetricDifferenceCoerciveWith( ...$iterables)`                          |
 | [`takeWhile`](#Take-While-1)                                              | Отдает элементы из коллекции, пока предикат возвращает истину                                                | `$stream->takeWhile($predicate)`                                                  |
@@ -190,18 +195,21 @@ $result = Stream::of([1, 1, 2, 2, 3, 4, 5])
 | [`sameCountWith`](#Same-Count-With) | Истинно, если данные коллекции имеют одинаковую длину                          | `$stream->sameCountWith(...$iterables)` |
 
 ##### Редуцирование
-| Terminal Operation             | Description                                                         | Code Snippet                                            |
-|--------------------------------|---------------------------------------------------------------------|---------------------------------------------------------|
-| [`toAverage`](#To-Average-1)   | Среднее арфиметическое элементов коллекции                          | `$stream->toAverage()`                                  |
-| [`toCount`](#To-Count-1)       | Длина коллекции                                                     | `$stream->toCount()`                                    |
-| [`toMax`](#To-Max-1)           | Максимальное значение из элементов коллекции                        | `$stream->toMax([$comparator])`                         |
-| [`toMin`](#To-Min-1)           | Минимальное значение из элементов коллекции                         | `$stream->toMin([$comparator])`                         |
-| [`toMinMax`](#To-Min-Max-1)    | Минимальное и максимальное значения из элементов коллекции          | `$stream->toMinMax([$comparator])`                      |
-| [`toProduct`](#To-Product-1)   | Произведение элементов коллекции                                    | `$stream->toProduct()`                                  |
-| [`toString`](#To-String-1)     | Преобразование коллекции в строку                                   | `$stream->toString([$separator], [$prefix], [$suffix])` |
-| [`toSum`](#To-Sum-1)           | Сумма элементов коллекции                                           | `$stream->toSum()`                                      |
-| [`toRange`](#To-Range-1)       | Разница между максимальным и минимальным элементами коллекции       | `$stream->toRange()`                                    |
-| [`toValue`](#To-Value-1)       | Редуцирование коллекции до значения, вычисляемого callback-функцией | `$stream->toValue($reducer, $initialValue)`             |
+| Terminal Operation                       | Description                                                         | Code Snippet                                            |
+|------------------------------------------|---------------------------------------------------------------------|---------------------------------------------------------|
+| [`toAverage`](#To-Average-1)             | Среднее арфиметическое элементов коллекции                          | `$stream->toAverage()`                                  |
+| [`toCount`](#To-Count-1)                 | Длина коллекции                                                     | `$stream->toCount()`                                    |
+| [`toFirst`](#To-First-1)                 | Первый элемент коллекции                                            | `$stream->toFirst()`                                    |
+| [`toFirstAndLast`](#To-First-And-Last-1) | Первый и последни элементы коллекции                                | `$stream->toFirstAndLast()`                             |
+| [`toLast`](#To-Last-1)                   | Последний элемент коллекции                                         | `$stream->toLast()`                                     |
+| [`toMax`](#To-Max-1)                     | Максимальное значение из элементов коллекции                        | `$stream->toMax([$compareBy])`                          |
+| [`toMin`](#To-Min-1)                     | Минимальное значение из элементов коллекции                         | `$stream->toMin([$compareBy])`                          |
+| [`toMinMax`](#To-Min-Max-1)              | Минимальное и максимальное значения из элементов коллекции          | `$stream->toMinMax([$compareBy])`                       |
+| [`toProduct`](#To-Product-1)             | Произведение элементов коллекции                                    | `$stream->toProduct()`                                  |
+| [`toString`](#To-String-1)               | Преобразование коллекции в строку                                   | `$stream->toString([$separator], [$prefix], [$suffix])` |
+| [`toSum`](#To-Sum-1)                     | Сумма элементов коллекции                                           | `$stream->toSum()`                                      |
+| [`toRange`](#To-Range-1)                 | Разница между максимальным и минимальным элементами коллекции       | `$stream->toRange()`                                    |
+| [`toValue`](#To-Value-1)                 | Редуцирование коллекции до значения, вычисляемого callback-функцией | `$stream->toValue($reducer, $initialValue)`             |
 
 ##### Операции конвертации
 | Terminal Operation             | Description                              | Code Snippet                                            |
@@ -580,6 +588,24 @@ foreach (Single::repeat($data, $repetitions) as $repeated) {
     print($repeated);
 }
 // 'Beetlejuice', 'Beetlejuice', 'Beetlejuice'
+```
+
+### Sort
+Сортирует коллекцию.
+
+```Single::sort(iterable $data, callable $comparator = null)```
+
+Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+
+```php
+use IterTools\Single;
+
+$data = [3, 4, 5, 9, 8, 7, 1, 6, 2];
+
+foreach (Single::sort($data) as $datum) {
+    print($datum);
+}
+// 1, 2, 3, 4, 5, 6, 7, 8, 9
 ```
 
 ### String
@@ -1230,10 +1256,58 @@ $length = Reduce::toCount($someIterable);
 // 3
 ```
 
+### To First
+Возвращает первый элемент коллекции.
+
+```Reduce::toFirst(iterable $data): mixed```
+
+Бросает `\LengthException` если коллекция пуста.
+
+```php
+use IterTools\Reduce;
+
+$input = [10, 20, 30];
+
+$result = Reduce::toFirst($input);
+// 10
+```
+
+### To First And Last
+Возвращает первый и последний элементы коллекции.
+
+```Reduce::toFirstAndLast(iterable $data): array{mixed, mixed}```
+
+Бросает `\LengthException` если хранимая в потоке коллекция пуста.
+
+```php
+use IterTools\Reduce;
+
+$input = [10, 20, 30];
+
+$result = Reduce::toFirstAndLast($input);
+// [10, 30]
+```
+
+### To Last
+Возвращает последний элемент коллекции.
+
+```Reduce::toLast(iterable $data): mixed```
+
+Бросает `\LengthException` если коллекция пуста.
+
+```php
+use IterTools\Reduce;
+
+$input = [10, 20, 30];
+
+$result = Reduce::toLast($input);
+// 30
+```
+
 ### To Max
 Возвращает максимальный элемент коллекции.
 
-```Reduce::toMax(iterable $data, callable|null $compareBy = null): mixed|null```
+```Reduce::toMax(iterable $data, callable $compareBy = null): mixed|null```
 
 - Функция `$compareBy` должна возвращать сравнимое значение.
 - Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
@@ -1251,7 +1325,7 @@ $result = Reduce::toMax($numbers);
 ### To Min
 Возвращает минимальный элемент коллекции.
 
-```Reduce::toMin(iterable $data, callable|null $compareBy = null): mixed|null```
+```Reduce::toMin(iterable $data, callable $compareBy = null): mixed|null```
 
 - Функция `$compareBy` должна возвращать сравнимое значение.
 - Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
@@ -1269,7 +1343,7 @@ $result = Reduce::toMin($numbers);
 ### To Min Max
 Возвращает минимальный и максимальный элементы коллекции.
 
-```Reduce::toMinMax(iterable $numbers, callable|null $compareBy = null): array```
+```Reduce::toMinMax(iterable $numbers, callable $compareBy = null): array```
 
 - Функция `$compareBy` должна возвращать сравнимое значение.
 - Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
@@ -1915,6 +1989,24 @@ $result = Stream::of($input)
 // 1, 3, 6, 10, 15
 ```
 
+### Sort
+Сортирует хранимую в потоке коллекцию.
+
+```$stream->sort(callable $comparator = null)```
+
+Если `$comparator` не передан, элементы хранимой коллекции должны быть сравнимы.
+
+```php
+use IterTools\Stream;
+
+$input = [3, 4, 5, 9, 8, 7, 1, 6, 2];
+
+$result = Stream::of($input)
+    ->sort()
+    ->toArray();
+// 1, 2, 3, 4, 5, 6, 7, 8, 9
+```
+
 #### Symmetric difference With
 Возвращает поток, содержащий симметрическую разность исходного потока с заданным набором коллекций.
 
@@ -2237,10 +2329,61 @@ $result = Stream::of($iterable)
 // 5
 ```
 
+### To First
+Возвращает первый элемент из коллекции в потоке.
+
+```$stream->toFirst(): mixed```
+
+Бросает `\LengthException` если хранимая в потоке коллекция пуста.
+
+```php
+use IterTools\Stream;
+
+$input = [10, 20, 30];
+
+$result = Stream::of($input)
+    ->toFirst();
+// 10
+```
+
+### To First And Last
+Возвращает первый и последний элементы из коллекции в потоке.
+
+```$stream->toFirstAndLast(): array{mixed, mixed}```
+
+Бросает `\LengthException` если хранимая в потоке коллекция пуста.
+
+```php
+use IterTools\Stream;
+
+$input = [10, 20, 30];
+
+$result = Stream::of($input)
+    ->toFirstAndLast();
+// [10, 30]
+```
+
+### To Last
+Возвращает последний элемент из коллекции в потоке.
+
+```$stream->toLast(): mixed```
+
+Бросает `\LengthException` если хранимая в потоке коллекция пуста.
+
+```php
+use IterTools\Stream;
+
+$input = [10, 20, 30];
+
+$result = Stream::of($input)
+    ->toLast();
+// 30
+```
+
 ##### To Max
 Возвращает максимальный элемент коллекции из потока.
 
-```$stream->toMax(callable|null $compareBy = null): mixed```
+```$stream->toMax(callable $compareBy = null): mixed```
 
 Функция `$compareBy` должна возвращать сравнимое значение.
 
@@ -2261,7 +2404,7 @@ $result = Stream::of($iterable)
 ##### To Min
 Возвращает минимальный элемент коллекции из потока.
 
-```$stream->toMin(callable|null $compareBy = null): mixed```
+```$stream->toMin(callable $compareBy = null): mixed```
 
 Функция `$compareBy` должна возвращать сравнимое значение.
 
@@ -2282,7 +2425,7 @@ $result = Stream::of($iterable)
 ##### To Min Max
 Возвращает минимальный и максимальный элементы коллекции из потока.
 
-```$stream->toMinMax(callable|null $compareBy = null): array```
+```$stream->toMinMax(callable $compareBy = null): array```
 
 Функция `$compareBy` должна возвращать сравнимое значение.
 

--- a/docs/README-RU.md
+++ b/docs/README-RU.md
@@ -122,9 +122,9 @@ $result = Stream::of([1, 1, 2, 2, 3, 4, 5])
 |----------------------------|-------------------------------------------------------------------------------------|---------------------------------------------------------------|
 | [`toAverage`](#To-Average) | Среднее арифметическое элементов коллекции                                          | `Reduce::toAverage($numbers)`                                 |
 | [`toCount`](#To-Count)     | Длина коллекции                                                                     | `Reduce::toCount($data)`                                      |
-| [`toMax`](#To-Max)         | Максимальный элемент коллекции                                                      | `Reduce::toMax($numbers, [$comparator])`                      |
-| [`toMin`](#To-Min)         | Минимальный элемент коллекции                                                       | `Reduce::toMin($numbers, [$comparator])`                      |
-| [`toMinMax`](#To-Min-Max)  | Минимальный и максимальный элемент коллекции                                        | `Reduce::toMinMax($numbers, [$comparator])`                   |
+| [`toMax`](#To-Max)         | Максимальный элемент коллекции                                                      | `Reduce::toMax($numbers, [$compareBy])`                       |
+| [`toMin`](#To-Min)         | Минимальный элемент коллекции                                                       | `Reduce::toMin($numbers, [$compareBy])`                       |
+| [`toMinMax`](#To-Min-Max)  | Минимальный и максимальный элемент коллекции                                        | `Reduce::toMinMax($numbers, [$compareBy])`                    |
 | [`toProduct`](#To-Product) | Произведение элементов коллекции                                                    | `Reduce::toProduct($numbers)`                                 |
 | [`toRange`](#To-Range)     | Разница между максимальным и минимальным элементами коллекции                       | `Reduce::toRange($numbers)`                                   |
 | [`toString`](#To-String)   | Преобразование коллекции в строку                                                   | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
@@ -1233,9 +1233,10 @@ $length = Reduce::toCount($someIterable);
 ### To Max
 Возвращает максимальный элемент коллекции.
 
-```Reduce::toMax(iterable $data, callable|null $comparator = null): mixed|null```
+```Reduce::toMax(iterable $data, callable|null $compareBy = null): mixed|null```
 
-- Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+- Функция `$compareBy` должна возвращать сравнимое значение.
+- Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
 - Для пустой коллекции возвращает `null`.
 
 ```php
@@ -1250,9 +1251,10 @@ $result = Reduce::toMax($numbers);
 ### To Min
 Возвращает минимальный элемент коллекции.
 
-```Reduce::toMin(iterable $data, callable|null $comparator = null): mixed|null```
+```Reduce::toMin(iterable $data, callable|null $compareBy = null): mixed|null```
 
-- Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+- Функция `$compareBy` должна возвращать сравнимое значение.
+- Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
 - Для пустой коллекции возвращает `null`.
 
 ```php
@@ -1267,9 +1269,10 @@ $result = Reduce::toMin($numbers);
 ### To Min Max
 Возвращает минимальный и максимальный элементы коллекции.
 
-```Reduce::toMinMax(iterable $numbers, callable|null $comparator = null): array```
+```Reduce::toMinMax(iterable $numbers, callable|null $compareBy = null): array```
 
-- Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+- Функция `$compareBy` должна возвращать сравнимое значение.
+- Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
 - Для пустой коллекции возвращает `[null, null]`.
 
 ```php
@@ -2237,9 +2240,11 @@ $result = Stream::of($iterable)
 ##### To Max
 Возвращает максимальный элемент коллекции из потока.
 
-```$stream->toMax(callable|null $comparator = null): mixed```
+```$stream->toMax(callable|null $compareBy = null): mixed```
 
-Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+Функция `$compareBy` должна возвращать сравнимое значение.
+
+Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
 
 Для пустой коллекции вернет `null`.
 
@@ -2256,9 +2261,11 @@ $result = Stream::of($iterable)
 ##### To Min
 Возвращает минимальный элемент коллекции из потока.
 
-```$stream->toMin(callable|null $comparator = null): mixed```
+```$stream->toMin(callable|null $compareBy = null): mixed```
 
-Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+Функция `$compareBy` должна возвращать сравнимое значение.
+
+Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
 
 Для пустой коллекции вернет `null`.
 
@@ -2275,9 +2282,11 @@ $result = Stream::of($iterable)
 ##### To Min Max
 Возвращает минимальный и максимальный элементы коллекции из потока.
 
-```$stream->toMinMax(callable|null $comparator = null): array```
+```$stream->toMinMax(callable|null $compareBy = null): array```
 
-Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+Функция `$compareBy` должна возвращать сравнимое значение.
+
+Если аргумент `$compareBy` не передан, элементы коллекции должны быть сравнимы.
 
 Для пустой коллекции вернет `[null, null]`.
 

--- a/docs/README-RU.md
+++ b/docs/README-RU.md
@@ -122,9 +122,9 @@ $result = Stream::of([1, 1, 2, 2, 3, 4, 5])
 |----------------------------|-------------------------------------------------------------------------------------|---------------------------------------------------------------|
 | [`toAverage`](#To-Average) | Среднее арифметическое элементов коллекции                                          | `Reduce::toAverage($numbers)`                                 |
 | [`toCount`](#To-Count)     | Длина коллекции                                                                     | `Reduce::toCount($data)`                                      |
-| [`toMax`](#To-Max)         | Максимальный элемент коллекции                                                      | `Reduce::toMax($numbers)`                                     |
-| [`toMin`](#To-Min)         | Минимальный элемент коллекции                                                       | `Reduce::toMin($numbers)`                                     |
-| [`toMinMax`](#To-Min-Max)  | Минимальный и максимальный элемент коллекции                                        | `Reduce::toMinMax($numbers)`                                  |
+| [`toMax`](#To-Max)         | Максимальный элемент коллекции                                                      | `Reduce::toMax($numbers, [$comparator])`                      |
+| [`toMin`](#To-Min)         | Минимальный элемент коллекции                                                       | `Reduce::toMin($numbers, [$comparator])`                      |
+| [`toMinMax`](#To-Min-Max)  | Минимальный и максимальный элемент коллекции                                        | `Reduce::toMinMax($numbers, [$comparator])`                   |
 | [`toProduct`](#To-Product) | Произведение элементов коллекции                                                    | `Reduce::toProduct($numbers)`                                 |
 | [`toRange`](#To-Range)     | Разница между максимальным и минимальным элементами коллекции                       | `Reduce::toRange($numbers)`                                   |
 | [`toString`](#To-String)   | Преобразование коллекции в строку                                                   | `Reduce::toString($data, [$separator], [$prefix], [$suffix])` |
@@ -194,12 +194,12 @@ $result = Stream::of([1, 1, 2, 2, 3, 4, 5])
 |--------------------------------|---------------------------------------------------------------------|---------------------------------------------------------|
 | [`toAverage`](#To-Average-1)   | Среднее арфиметическое элементов коллекции                          | `$stream->toAverage()`                                  |
 | [`toCount`](#To-Count-1)       | Длина коллекции                                                     | `$stream->toCount()`                                    |
-| [`toMax`](#To-Max-1)           | Максимальное значение из элементов коллекции                        | `$stream->toMax()`                                      |
-| [`toMin`](#To-Min-1)           | Минимальное значение из элементов коллекции                         | `$stream->toMin()`                                      |
+| [`toMax`](#To-Max-1)           | Максимальное значение из элементов коллекции                        | `$stream->toMax([$comparator])`                         |
+| [`toMin`](#To-Min-1)           | Минимальное значение из элементов коллекции                         | `$stream->toMin([$comparator])`                         |
+| [`toMinMax`](#To-Min-Max-1)    | Минимальное и максимальное значения из элементов коллекции          | `$stream->toMinMax([$comparator])`                      |
 | [`toProduct`](#To-Product-1)   | Произведение элементов коллекции                                    | `$stream->toProduct()`                                  |
 | [`toString`](#To-String-1)     | Преобразование коллекции в строку                                   | `$stream->toString([$separator], [$prefix], [$suffix])` |
 | [`toSum`](#To-Sum-1)           | Сумма элементов коллекции                                           | `$stream->toSum()`                                      |
-| [`toMinMax`](#To-Min-Max-1)    | Минимальное и максимальное значения из элементов коллекции          | `$stream->toMinMax()`                                   |
 | [`toRange`](#To-Range-1)       | Разница между максимальным и минимальным элементами коллекции       | `$stream->toRange()`                                    |
 | [`toValue`](#To-Value-1)       | Редуцирование коллекции до значения, вычисляемого callback-функцией | `$stream->toValue($reducer, $initialValue)`             |
 
@@ -1233,10 +1233,10 @@ $length = Reduce::toCount($someIterable);
 ### To Max
 Возвращает максимальный элемент коллекции.
 
-- Элементы коллекции должны быть сравнимы.
-- Для пустой коллекции возвращает `null`.
+```Reduce::toMax(iterable $data, callable|null $comparator = null): mixed|null```
 
-```Reduce::toMax(iterable $data): mixed|null```
+- Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+- Для пустой коллекции возвращает `null`.
 
 ```php
 use IterTools\Reduce;
@@ -1250,10 +1250,10 @@ $result = Reduce::toMax($numbers);
 ### To Min
 Возвращает минимальный элемент коллекции.
 
-- Элементы коллекции должны быть сравнимы.
-- Для пустой коллекции возвращает `null`.
+```Reduce::toMin(iterable $data, callable|null $comparator = null): mixed|null```
 
-```Reduce::toMin(iterable $data): mixed|null```
+- Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+- Для пустой коллекции возвращает `null`.
 
 ```php
 use IterTools\Reduce;
@@ -1267,9 +1267,10 @@ $result = Reduce::toMin($numbers);
 ### To Min Max
 Возвращает минимальный и максимальный элементы коллекции.
 
-```Reduce::toMinMax(iterable $numbers): array```
+```Reduce::toMinMax(iterable $numbers, callable|null $comparator = null): array```
 
-Для пустой коллекции возвращает `[null, null]`.
+- Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
+- Для пустой коллекции возвращает `[null, null]`.
 
 ```php
 use IterTools\Reduce;
@@ -2236,9 +2237,9 @@ $result = Stream::of($iterable)
 ##### To Max
 Возвращает максимальный элемент коллекции из потока.
 
-```$stream->toMax(): mixed```
+```$stream->toMax(callable|null $comparator = null): mixed```
 
-Элементы в коллекции должны быть сравнимы.
+Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
 
 Для пустой коллекции вернет `null`.
 
@@ -2255,9 +2256,9 @@ $result = Stream::of($iterable)
 ##### To Min
 Возвращает минимальный элемент коллекции из потока.
 
-```$stream->toMin(): mixed```
+```$stream->toMin(callable|null $comparator = null): mixed```
 
-Элементы в коллекции должны быть сравнимы.
+Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
 
 Для пустой коллекции вернет `null`.
 
@@ -2274,7 +2275,9 @@ $result = Stream::of($iterable)
 ##### To Min Max
 Возвращает минимальный и максимальный элементы коллекции из потока.
 
-```$stream->toMinMax(): array```
+```$stream->toMinMax(callable|null $comparator = null): array```
+
+Если `$comparator` не передан, элементы коллекции должны быть сравнимы.
 
 Для пустой коллекции вернет `[null, null]`.
 

--- a/src/Reduce.php
+++ b/src/Reduce.php
@@ -32,23 +32,31 @@ class Reduce
     /**
      * Reduces given iterable to its min value.
      *
-     * Items of given collection must be comparable.
+     * If comparator is null then items of given collection must be comparable.
      *
      * Returns null if given collection is empty.
      *
      * @param iterable<mixed> $data
+     * @param callable|null   $comparator
      *
      * @return mixed|null
      */
-    public static function toMin(iterable $data)
+    public static function toMin(iterable $data, ?callable $comparator = null)
     {
+        if ($comparator !== null) {
+            return static::toValue(
+                $data,
+                fn ($carry, $datum) => $comparator($datum, $carry ?? $datum) <= 0 ? $datum : $carry
+            );
+        }
+
         return static::toValue($data, fn ($carry, $datum) => \min($carry ?? $datum, $datum));
     }
 
     /**
      * Reduces given iterable to its max value.
      *
-     * Items of given collection must be comparable.
+     * If comparator is null then items of given collection must be comparable.
      *
      * Returns null if given collection is empty.
      *

--- a/src/Reduce.php
+++ b/src/Reduce.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace IterTools;
 
+use IterTools\Util\NoValueMonad;
+
 class Reduce
 {
     /**
@@ -205,5 +207,55 @@ class Reduce
         [$min, $max] = static::toMinMax($numbers);
 
         return ($max ?? 0) - ($min ?? 0);
+    }
+
+    /**
+     * Reduces given collection to its first value.
+     *
+     * @param iterable<mixed> $data
+     * @return mixed
+     *
+     * @throws \LengthException if collection is empty
+     */
+    public static function toFirst(iterable $data)
+    {
+        foreach ($data as $datum) {
+            return $datum;
+        }
+
+        throw new \LengthException('collection is empty');
+    }
+
+    /**
+     * Reduces given collection to its last value.
+     *
+     * @param iterable<mixed> $data
+     * @return mixed
+     *
+     * @throws \LengthException if collection is empty
+     */
+    public static function toLast(iterable $data)
+    {
+        /** @var mixed|NoValueMonad $result */
+        $result = static::toValue($data, fn ($carry, $datum) => $datum, NoValueMonad::getInstance());
+
+        if ($result instanceof NoValueMonad) {
+            throw new \LengthException('collection is empty');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reduces given collection to its first and last values.
+     *
+     * @param iterable<mixed> $data
+     * @return array{mixed, mixed}
+     *
+     * @throws \LengthException if collection is empty
+     */
+    public static function toFirstAndLast(iterable $data): array
+    {
+        return [static::toFirst($data), static::toLast($data)];
     }
 }

--- a/src/Reduce.php
+++ b/src/Reduce.php
@@ -34,21 +34,28 @@ class Reduce
     /**
      * Reduces given iterable to its min value.
      *
-     * If comparator is null then items of given collection must be comparable.
+     * $comparableGetter must return comparable value.
+     *
+     * If $comparableGetter is not proposed then items of given collection must be comparable.
      *
      * Returns null if given collection is empty.
      *
      * @param iterable<mixed> $data
-     * @param callable|null   $comparator
+     * @param callable|null   $comparableGetter
      *
      * @return mixed|null
      */
-    public static function toMin(iterable $data, callable $comparator = null)
+    public static function toMin(iterable $data, callable $comparableGetter = null)
     {
-        if ($comparator !== null) {
+        if ($comparableGetter !== null) {
             return static::toValue(
                 $data,
-                fn ($carry, $datum) => $comparator($datum, $carry ?? $datum) <= 0 ? $datum : $carry
+                static function ($carry, $datum) use ($comparableGetter) {
+                    if ($comparableGetter($datum) < $comparableGetter($carry ?? $datum)) {
+                        return $datum;
+                    }
+                    return $carry ?? $datum;
+                }
             );
         }
 
@@ -58,21 +65,28 @@ class Reduce
     /**
      * Reduces given iterable to its max value.
      *
-     * If comparator is null then items of given collection must be comparable.
+     * $comparableGetter must return comparable value.
+     *
+     * If $comparableGetter is not proposed then items of given collection must be comparable.
      *
      * Returns null if given collection is empty.
      *
      * @param iterable<mixed> $data
-     * @param callable|null   $comparator
+     * @param callable|null   $comparableGetter
      *
      * @return mixed|null
      */
-    public static function toMax(iterable $data, callable $comparator = null)
+    public static function toMax(iterable $data, callable $comparableGetter = null)
     {
-        if ($comparator !== null) {
+        if ($comparableGetter !== null) {
             return static::toValue(
                 $data,
-                fn ($carry, $datum) => $comparator($datum, $carry ?? $datum) >= 0 ? $datum : $carry
+                static function ($carry, $datum) use ($comparableGetter) {
+                    if ($comparableGetter($datum) > $comparableGetter($carry ?? $datum)) {
+                        return $datum;
+                    }
+                    return $carry ?? $datum;
+                }
             );
         }
 

--- a/src/Reduce.php
+++ b/src/Reduce.php
@@ -164,17 +164,31 @@ class Reduce
     /**
      * Reduces given collection to array of its upper and lower bounds.
      *
+     * If comparator is null then items of given collection must be comparable.
+     *
      * Returns [null, null] if given collection is empty.
      *
      * @param iterable<numeric> $numbers
+     * @param callable|null   $comparator
      *
      * @return array{numeric, numeric}|array{null, null}
      */
-    public static function toMinMax(iterable $numbers): array
+    public static function toMinMax(iterable $numbers, ?callable $comparator = null): array
     {
-        return static::toValue($numbers, static function ($carry, $datum) {
-            return [\min($carry[0] ?? $datum, $datum), \max($carry[1] ?? $datum, $datum)];
-        }, [null, null]);
+        if ($comparator !== null) {
+            return static::toValue($numbers, static function ($carry, $datum) use ($comparator) {
+                return [
+                    $comparator($datum, $carry[0] ?? $datum) <= 0 ? $datum : $carry[0],
+                    $comparator($datum, $carry[1] ?? $datum) >= 0 ? $datum : $carry[1],
+                ];
+            }, [null, null]);
+        }
+
+        return static::toValue(
+            $numbers,
+            fn ($carry, $datum) => [\min($carry[0] ?? $datum, $datum), \max($carry[1] ?? $datum, $datum)],
+            [null, null]
+        );
     }
 
     /**

--- a/src/Reduce.php
+++ b/src/Reduce.php
@@ -43,7 +43,7 @@ class Reduce
      *
      * @return mixed|null
      */
-    public static function toMin(iterable $data, ?callable $comparator = null)
+    public static function toMin(iterable $data, callable $comparator = null)
     {
         if ($comparator !== null) {
             return static::toValue(
@@ -67,7 +67,7 @@ class Reduce
      *
      * @return mixed|null
      */
-    public static function toMax(iterable $data, ?callable $comparator = null)
+    public static function toMax(iterable $data, callable $comparator = null)
     {
         if ($comparator !== null) {
             return static::toValue(
@@ -175,7 +175,7 @@ class Reduce
      *
      * @return array{numeric, numeric}|array{null, null}
      */
-    public static function toMinMax(iterable $numbers, ?callable $comparator = null): array
+    public static function toMinMax(iterable $numbers, callable $comparator = null): array
     {
         if ($comparator !== null) {
             return static::toValue($numbers, static function ($carry, $datum) use ($comparator) {

--- a/src/Reduce.php
+++ b/src/Reduce.php
@@ -42,9 +42,7 @@ class Reduce
      */
     public static function toMin(iterable $data)
     {
-        return static::toValue($data, static function ($carry, $datum) {
-            return \min($carry ?? $datum, $datum);
-        });
+        return static::toValue($data, fn ($carry, $datum) => \min($carry ?? $datum, $datum));
     }
 
     /**
@@ -55,14 +53,20 @@ class Reduce
      * Returns null if given collection is empty.
      *
      * @param iterable<mixed> $data
+     * @param callable|null   $comparator
      *
      * @return mixed|null
      */
-    public static function toMax(iterable $data)
+    public static function toMax(iterable $data, ?callable $comparator = null)
     {
-        return static::toValue($data, static function ($carry, $datum) {
-            return \max($carry ?? $datum, $datum);
-        });
+        if ($comparator !== null) {
+            return static::toValue(
+                $data,
+                fn ($carry, $datum) => $comparator($datum, $carry ?? $datum) >= 0 ? $datum : $carry
+            );
+        }
+
+        return static::toValue($data, fn ($carry, $datum) => \max($carry ?? $datum, $datum));
     }
 
     /**
@@ -78,9 +82,7 @@ class Reduce
             return \count($data);
         }
 
-        return static::toValue($data, static function ($carry) {
-            return $carry + 1;
-        }, 0);
+        return static::toValue($data, fn ($carry) => $carry + 1, 0);
     }
 
     /**
@@ -92,9 +94,7 @@ class Reduce
      */
     public static function toSum(iterable $data)
     {
-        return static::toValue($data, static function ($carry, $datum) {
-            return $carry + $datum;
-        }, 0);
+        return static::toValue($data, fn ($carry, $datum) => $carry + $datum, 0);
     }
 
     /**
@@ -108,9 +108,7 @@ class Reduce
      */
     public static function toProduct(iterable $data)
     {
-        return static::toValue($data, static function ($carry, $datum) {
-            return ($carry ?? 1) * $datum;
-        });
+        return static::toValue($data, fn ($carry, $datum) => ($carry ?? 1) * $datum);
     }
 
     /**

--- a/src/Single.php
+++ b/src/Single.php
@@ -361,7 +361,7 @@ class Single
      *
      * @return \Generator
      */
-    public static function sort(iterable $data, ?callable $comparator = null): \Generator
+    public static function sort(iterable $data, callable $comparator = null): \Generator
     {
         $result = iterator_to_array(IteratorFactory::makeIterator($data));
 

--- a/src/Single.php
+++ b/src/Single.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace IterTools;
 
+use IterTools\Util\IteratorFactory;
+use IterTools\Util\SortHelper;
+
 class Single
 {
     /**
@@ -345,6 +348,31 @@ class Single
     {
         foreach ($data as $datum) {
             yield $func($datum);
+        }
+    }
+
+    /**
+     * Sorts the given iterable
+     *
+     * If comparator is null, the elements of given iterable must be comparable.
+     *
+     * @param iterable<mixed> $data
+     * @param callable|null $comparator
+     *
+     * @return \Generator
+     */
+    public static function sort(iterable $data, ?callable $comparator = null): \Generator
+    {
+        $result = iterator_to_array(IteratorFactory::makeIterator($data));
+
+        if ($comparator === null) {
+            sort($result);
+        } else {
+            usort($result, $comparator);
+        }
+
+        foreach ($result as $datum) {
+            yield $datum;
         }
     }
 }

--- a/src/Single.php
+++ b/src/Single.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace IterTools;
 
 use IterTools\Util\IteratorFactory;
-use IterTools\Util\SortHelper;
 
 class Single
 {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -1014,33 +1014,37 @@ class Stream implements \IteratorAggregate
     /**
      * Reduces iterable source to its max value.
      *
-     * Items of iterable source must be comparable.
+     * If comparator is null then items of iterable source must be comparable.
      *
      * Returns null if iterable source is empty.
+     *
+     * @param callable|null $comparator
      *
      * @return mixed
      *
      * @see Reduce::toMax()
      */
-    public function toMax()
+    public function toMax(?callable $comparator = null)
     {
-        return Reduce::toMax($this->iterable);
+        return Reduce::toMax($this->iterable, $comparator);
     }
 
     /**
      * Reduces iterable source to its min value.
      *
-     * Items of iterable source must be comparable.
+     * If comparator is null then items of iterable source must be comparable.
      *
      * Returns null if iterable source is empty.
+     *
+     * @param callable|null $comparator
      *
      * @return mixed
      *
      * @see Reduce::toMin()
      */
-    public function toMin()
+    public function toMin(?callable $comparator = null)
     {
-        return Reduce::toMin($this->iterable);
+        return Reduce::toMin($this->iterable, $comparator);
     }
 
     /**
@@ -1095,17 +1099,21 @@ class Stream implements \IteratorAggregate
     /**
      * Reduces iterable source to array of its upper and lower bounds.
      *
+     * If comparator is null then items of iterable source must be comparable.
+     *
      * Returns [null, null] if iterable source is empty.
+     *
+     * @param callable|null $comparator
      *
      * @return array{numeric, numeric}|array{null, null}
      *
      * @see Reduce::toMinMax()
      */
-    public function toMinMax(): array
+    public function toMinMax(?callable $comparator = null): array
     {
         /** @var iterable<numeric> $iterable */
         $iterable = $this->iterable;
-        return Reduce::toMinMax($iterable);
+        return Reduce::toMinMax($iterable, $comparator);
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -426,7 +426,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Single::sort()
      */
-    public function sort(?callable $comparator = null): self
+    public function sort(callable $comparator = null): self
     {
         $this->iterable = Single::sort($this->iterable, $comparator);
         return $this;
@@ -1041,7 +1041,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Reduce::toMax()
      */
-    public function toMax(?callable $comparator = null)
+    public function toMax(callable $comparator = null)
     {
         return Reduce::toMax($this->iterable, $comparator);
     }
@@ -1059,7 +1059,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Reduce::toMin()
      */
-    public function toMin(?callable $comparator = null)
+    public function toMin(callable $comparator = null)
     {
         return Reduce::toMin($this->iterable, $comparator);
     }
@@ -1126,7 +1126,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Reduce::toMinMax()
      */
-    public function toMinMax(?callable $comparator = null): array
+    public function toMinMax(callable $comparator = null): array
     {
         /** @var iterable<numeric> $iterable */
         $iterable = $this->iterable;

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -1031,37 +1031,63 @@ class Stream implements \IteratorAggregate
     /**
      * Reduces iterable source to its max value.
      *
-     * If comparator is null then items of iterable source must be comparable.
+     * Callable param $compareBy must return comparable value.
+     *
+     * If $compareBy is not proposed then items of iterable source must be comparable.
      *
      * Returns null if iterable source is empty.
      *
-     * @param callable|null $comparator
+     * @param callable|null $compareBy
      *
      * @return mixed
      *
      * @see Reduce::toMax()
      */
-    public function toMax(callable $comparator = null)
+    public function toMax(callable $compareBy = null)
     {
-        return Reduce::toMax($this->iterable, $comparator);
+        return Reduce::toMax($this->iterable, $compareBy);
     }
 
     /**
      * Reduces iterable source to its min value.
      *
-     * If comparator is null then items of iterable source must be comparable.
+     * Callable param $compareBy must return comparable value.
+     *
+     * If $compareBy is not proposed then items of iterable source must be comparable.
      *
      * Returns null if iterable source is empty.
      *
-     * @param callable|null $comparator
+     * @param callable|null $compareBy
      *
      * @return mixed
      *
      * @see Reduce::toMin()
      */
-    public function toMin(callable $comparator = null)
+    public function toMin(callable $compareBy = null)
     {
-        return Reduce::toMin($this->iterable, $comparator);
+        return Reduce::toMin($this->iterable, $compareBy);
+    }
+
+    /**
+     * Reduces iterable source to array of its upper and lower bounds.
+     *
+     * Callable param $compareBy must return comparable value.
+     *
+     * If $compareBy is not proposed then items of iterable source must be comparable.
+     *
+     * Returns [null, null] if iterable source is empty.
+     *
+     * @param callable|null $compareBy
+     *
+     * @return array{numeric, numeric}|array{null, null}
+     *
+     * @see Reduce::toMinMax()
+     */
+    public function toMinMax(callable $compareBy = null): array
+    {
+        /** @var iterable<numeric> $iterable */
+        $iterable = $this->iterable;
+        return Reduce::toMinMax($iterable, $compareBy);
     }
 
     /**
@@ -1111,26 +1137,6 @@ class Stream implements \IteratorAggregate
         /** @var iterable<numeric> $iterable */
         $iterable = $this->iterable;
         return Reduce::toSum($iterable);
-    }
-
-    /**
-     * Reduces iterable source to array of its upper and lower bounds.
-     *
-     * If comparator is null then items of iterable source must be comparable.
-     *
-     * Returns [null, null] if iterable source is empty.
-     *
-     * @param callable|null $comparator
-     *
-     * @return array{numeric, numeric}|array{null, null}
-     *
-     * @see Reduce::toMinMax()
-     */
-    public function toMinMax(callable $comparator = null): array
-    {
-        /** @var iterable<numeric> $iterable */
-        $iterable = $this->iterable;
-        return Reduce::toMinMax($iterable, $comparator);
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -416,6 +416,23 @@ class Stream implements \IteratorAggregate
     }
 
     /**
+     * Sorts iterable source.
+     *
+     * If comparator is null, then elements of the iterable source must be comparable.
+     *
+     * @param callable|null $comparator
+     *
+     * @return $this
+     *
+     * @see Single::sort()
+     */
+    public function sort(?callable $comparator = null): self
+    {
+        $this->iterable = Single::sort($this->iterable, $comparator);
+        return $this;
+    }
+
+    /**
      * Chain iterable source withs given iterables together into a single iteration.
      *
      * Makes a single continuous sequence out of multiple sequences.
@@ -1130,6 +1147,42 @@ class Stream implements \IteratorAggregate
         /** @var iterable<numeric> $iterable */
         $iterable = $this->iterable;
         return Reduce::toRange($iterable);
+    }
+
+    /**
+     * Returns the first element of iterable source.
+     *
+     * @return mixed
+     *
+     * @throws \LengthException if iterable source is empty.
+     */
+    public function toFirst()
+    {
+        return Reduce::toFirst($this->iterable);
+    }
+
+    /**
+     * Returns the last element of iterable source.
+     *
+     * @return mixed
+     *
+     * @throws \LengthException if iterable source is empty.
+     */
+    public function toLast()
+    {
+        return Reduce::toLast($this->iterable);
+    }
+
+    /**
+     * Returns the first element of iterable source.
+     *
+     * @return array{mixed, mixed}
+     *
+     * @throws \LengthException if iterable source is empty.
+     */
+    public function toFirstAndLast(): array
+    {
+        return Reduce::toFirstAndLast($this->iterable);
     }
 
     /**

--- a/tests/Reduce/ToFirstAndLastTest.php
+++ b/tests/Reduce/ToFirstAndLastTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IterTools\Tests\Reduce;
+
+use IterTools\Reduce;
+use IterTools\Tests\Fixture\ArrayIteratorFixture;
+use IterTools\Tests\Fixture\DataProvider;
+use IterTools\Tests\Fixture\GeneratorFixture;
+use IterTools\Tests\Fixture\IteratorAggregateFixture;
+
+class ToFirstAndLastTest extends \PHPUnit\Framework\TestCase
+{
+    use DataProvider;
+
+    /**
+     * @dataProvider dataProviderForArray
+     * @param        array $data
+     * @param        mixed $expected
+     */
+    public function testArray(array $data, $expected)
+    {
+        // When
+        $result = Reduce::toFirstAndLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForArray(): array
+    {
+        return [
+            [
+                [0],
+                [0, 0],
+            ],
+            [
+                [null],
+                [null, null],
+            ],
+            [
+                [''],
+                ['', ''],
+            ],
+            [
+                ['', null],
+                ['', null],
+            ],
+            [
+                [3, 2],
+                [3, 2],
+            ],
+            [
+                [1, 2, 3],
+                [1, 3],
+            ],
+            [
+                [1.1, 1.1, 2.1, 2.1, 3.1, 3.1],
+                [1.1, 3.1],
+            ],
+            [
+                [[1], '2', 3],
+                [[1], 3],
+            ],
+            [
+                [false, [1], '2', 3],
+                [false, 3],
+            ],
+            [
+                [true, [1], '2', 3],
+                [true, 3],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForGenerators
+     * @param        \Generator $data
+     * @param        mixed $expected
+     */
+    public function testGenerators(\Generator $data, $expected)
+    {
+        // When
+        $result = Reduce::toFirstAndLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForGenerators(): array
+    {
+        $gen = fn (array $data) => GeneratorFixture::getGenerator($data);
+
+        return [
+            [
+                $gen([0]),
+                [0, 0],
+            ],
+            [
+                $gen([null]),
+                [null, null],
+            ],
+            [
+                $gen(['']),
+                ['', ''],
+            ],
+            [
+                $gen(['', null]),
+                ['', null],
+            ],
+            [
+                $gen([3, 2]),
+                [3, 2],
+            ],
+            [
+                $gen([1, 2, 3]),
+                [1, 3],
+            ],
+            [
+                $gen([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                [1.1, 3.1],
+            ],
+            [
+                $gen([[1], '2', 3]),
+                [[1], 3],
+            ],
+            [
+                $gen([false, [1], '2', 3]),
+                [false, 3],
+            ],
+            [
+                $gen([true, [1], '2', 3]),
+                [true, 3],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIterators
+     * @param        \Iterator $data
+     * @param        mixed $expected
+     */
+    public function testIterators(\Iterator $data, $expected)
+    {
+        // When
+        $result = Reduce::toFirstAndLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForIterators(): array
+    {
+        $iter = fn (array $data) => new ArrayIteratorFixture($data);
+
+        return [
+            [
+                $iter([0]),
+                [0, 0],
+            ],
+            [
+                $iter([null]),
+                [null, null],
+            ],
+            [
+                $iter(['']),
+                ['', ''],
+            ],
+            [
+                $iter(['', null]),
+                ['', null],
+            ],
+            [
+                $iter([3, 2]),
+                [3, 2],
+            ],
+            [
+                $iter([1, 2, 3]),
+                [1, 3],
+            ],
+            [
+                $iter([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                [1.1, 3.1],
+            ],
+            [
+                $iter([[1], '2', 3]),
+                [[1], 3],
+            ],
+            [
+                $iter([false, [1], '2', 3]),
+                [false, 3],
+            ],
+            [
+                $iter([true, [1], '2', 3]),
+                [true, 3],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTraversables
+     * @param        \Traversable $data
+     * @param        mixed $expected
+     */
+    public function testTraversables(\Traversable $data, $expected)
+    {
+        // When
+        $result = Reduce::toFirstAndLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForTraversables(): array
+    {
+        $trav = fn (array $data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                $trav([0]),
+                [0, 0],
+            ],
+            [
+                $trav([null]),
+                [null, null],
+            ],
+            [
+                $trav(['']),
+                ['', ''],
+            ],
+            [
+                $trav(['', null]),
+                ['', null],
+            ],
+            [
+                $trav([3, 2]),
+                [3, 2],
+            ],
+            [
+                $trav([1, 2, 3]),
+                [1, 3],
+            ],
+            [
+                $trav([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                [1.1, 3.1],
+            ],
+            [
+                $trav([[1], '2', 3]),
+                [[1], 3],
+            ],
+            [
+                $trav([false, [1], '2', 3]),
+                [false, 3],
+            ],
+            [
+                $trav([true, [1], '2', 3]),
+                [true, 3],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForEmptyIterable
+     * @param iterable $data
+     * @return void
+     */
+    public function testErrorOnEmptyCollection(iterable $data): void
+    {
+        $this->expectException(\LengthException::class);
+        Reduce::toFirstAndLast($data);
+    }
+}

--- a/tests/Reduce/ToFirstAndLastTest.php
+++ b/tests/Reduce/ToFirstAndLastTest.php
@@ -270,4 +270,47 @@ class ToFirstAndLastTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\LengthException::class);
         Reduce::toFirstAndLast($data);
     }
+
+    /**
+     * @dataProvider dataProviderForRewindableIterators
+     * @param \NoRewindIterator $data
+     * @param array $expected
+     * @return void
+     */
+    public function testRewindableIterators(\NoRewindIterator $data, array $expected): void
+    {
+        // When
+        $result = Reduce::toFirstAndLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForRewindableIterators(): array
+    {
+        $iter = fn (array $data) => new \NoRewindIterator(new \ArrayIterator($data));
+
+        return [
+            [
+                $iter([1]),
+                [1, 1],
+            ],
+            [
+                $iter([1.1]),
+                [1.1, 1.1],
+            ],
+            [
+                $iter([null]),
+                [null, null],
+            ],
+            [
+                $iter(['a']),
+                ['a', 'a'],
+            ],
+            [
+                $iter(['abc']),
+                ['abc', 'abc'],
+            ],
+        ];
+    }
 }

--- a/tests/Reduce/ToFirstTest.php
+++ b/tests/Reduce/ToFirstTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IterTools\Tests\Reduce;
+
+use IterTools\Reduce;
+use IterTools\Tests\Fixture\ArrayIteratorFixture;
+use IterTools\Tests\Fixture\DataProvider;
+use IterTools\Tests\Fixture\GeneratorFixture;
+use IterTools\Tests\Fixture\IteratorAggregateFixture;
+
+class ToFirstTest extends \PHPUnit\Framework\TestCase
+{
+    use DataProvider;
+
+    /**
+     * @dataProvider dataProviderForArray
+     * @param        array $data
+     * @param        mixed $expected
+     */
+    public function testArray(array $data, $expected): void
+    {
+        // When
+        $result = Reduce::toFirst($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForArray(): array
+    {
+        return [
+            [
+                [0],
+                0,
+            ],
+            [
+                [null],
+                null,
+            ],
+            [
+                [''],
+                '',
+            ],
+            [
+                ['', null],
+                '',
+            ],
+            [
+                [3, 2],
+                3,
+            ],
+            [
+                [1, 2, 3],
+                1,
+            ],
+            [
+                [1.1, 1.1, 2.1, 2.1, 3.1, 3.1],
+                1.1,
+            ],
+            [
+                [[1], '2', 3],
+                [1],
+            ],
+            [
+                [false, [1], '2', 3],
+                false,
+            ],
+            [
+                [true, [1], '2', 3],
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForGenerators
+     * @param        \Generator $data
+     * @param        mixed $expected
+     */
+    public function testGenerators(\Generator $data, $expected): void
+    {
+        // When
+        $result = Reduce::toFirst($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForGenerators(): array
+    {
+        $gen = fn (array $data) => GeneratorFixture::getGenerator($data);
+
+        return [
+            [
+                $gen([0]),
+                0,
+            ],
+            [
+                $gen([null]),
+                null,
+            ],
+            [
+                $gen(['']),
+                '',
+            ],
+            [
+                $gen(['', null]),
+                '',
+            ],
+            [
+                $gen([3, 2]),
+                3,
+            ],
+            [
+                $gen([1, 2, 3]),
+                1,
+            ],
+            [
+                $gen([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                1.1,
+            ],
+            [
+                $gen([[1], '2', 3]),
+                [1],
+            ],
+            [
+                $gen([false, [1], '2', 3]),
+                false,
+            ],
+            [
+                $gen([true, [1], '2', 3]),
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIterators
+     * @param        \Iterator $data
+     * @param        mixed $expected
+     */
+    public function testIterators(\Iterator $data, $expected): void
+    {
+        // When
+        $result = Reduce::toFirst($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForIterators(): array
+    {
+        $iter = fn (array $data) => new ArrayIteratorFixture($data);
+
+        return [
+            [
+                $iter([0]),
+                0,
+            ],
+            [
+                $iter([null]),
+                null,
+            ],
+            [
+                $iter(['']),
+                '',
+            ],
+            [
+                $iter(['', null]),
+                '',
+            ],
+            [
+                $iter([3, 2]),
+                3,
+            ],
+            [
+                $iter([1, 2, 3]),
+                1,
+            ],
+            [
+                $iter([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                1.1,
+            ],
+            [
+                $iter([[1], '2', 3]),
+                [1],
+            ],
+            [
+                $iter([false, [1], '2', 3]),
+                false,
+            ],
+            [
+                $iter([true, [1], '2', 3]),
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTraversables
+     * @param        \Traversable $data
+     * @param        mixed $expected
+     */
+    public function testTraversables(\Traversable $data, $expected): void
+    {
+        // When
+        $result = Reduce::toFirst($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForTraversables(): array
+    {
+        $trav = fn (array $data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                $trav([0]),
+                0,
+            ],
+            [
+                $trav([null]),
+                null,
+            ],
+            [
+                $trav(['']),
+                '',
+            ],
+            [
+                $trav(['', null]),
+                '',
+            ],
+            [
+                $trav([3, 2]),
+                3,
+            ],
+            [
+                $trav([1, 2, 3]),
+                1,
+            ],
+            [
+                $trav([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                1.1,
+            ],
+            [
+                $trav([[1], '2', 3]),
+                [1],
+            ],
+            [
+                $trav([false, [1], '2', 3]),
+                false,
+            ],
+            [
+                $trav([true, [1], '2', 3]),
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForEmptyIterable
+     * @param iterable $data
+     * @return void
+     */
+    public function testErrorOnEmptyCollection(iterable $data): void
+    {
+        $this->expectException(\LengthException::class);
+        Reduce::toFirst($data);
+    }
+}

--- a/tests/Reduce/ToLastTest.php
+++ b/tests/Reduce/ToLastTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IterTools\Tests\Reduce;
+
+use IterTools\Reduce;
+use IterTools\Tests\Fixture\ArrayIteratorFixture;
+use IterTools\Tests\Fixture\DataProvider;
+use IterTools\Tests\Fixture\GeneratorFixture;
+use IterTools\Tests\Fixture\IteratorAggregateFixture;
+
+class ToLastTest extends \PHPUnit\Framework\TestCase
+{
+    use DataProvider;
+
+    /**
+     * @dataProvider dataProviderForArray
+     * @param        array $data
+     * @param        mixed $expected
+     */
+    public function testArray(array $data, $expected): void
+    {
+        // When
+        $result = Reduce::toLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForArray(): array
+    {
+        return [
+            [
+                [0],
+                0,
+            ],
+            [
+                [null],
+                null,
+            ],
+            [
+                [''],
+                '',
+            ],
+            [
+                ['', null],
+                null,
+            ],
+            [
+                [3, 2],
+                2,
+            ],
+            [
+                [1, 2, 3],
+                3,
+            ],
+            [
+                [1.1, 1.1, 2.1, 2.1, 3.1, 3.1],
+                3.1,
+            ],
+            [
+                [[1], '2', 3],
+                3,
+            ],
+            [
+                [false, [1], '2', 3],
+                3,
+            ],
+            [
+                [true, [1], '2', 3],
+                3,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForGenerators
+     * @param        \Generator $data
+     * @param        mixed $expected
+     */
+    public function testGenerators(\Generator $data, $expected): void
+    {
+        // When
+        $result = Reduce::toLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForGenerators(): array
+    {
+        $gen = fn (array $data) => GeneratorFixture::getGenerator($data);
+
+        return [
+            [
+                $gen([0]),
+                0,
+            ],
+            [
+                $gen([null]),
+                null,
+            ],
+            [
+                $gen(['']),
+                '',
+            ],
+            [
+                $gen(['', null]),
+                null,
+            ],
+            [
+                $gen([3, 2]),
+                2,
+            ],
+            [
+                $gen([1, 2, 3]),
+                3,
+            ],
+            [
+                $gen([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                3.1,
+            ],
+            [
+                $gen([[1], '2', 3]),
+                3,
+            ],
+            [
+                $gen([false, [1], '2', 3]),
+                3,
+            ],
+            [
+                $gen([true, [1], '2', 3]),
+                3,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIterators
+     * @param        \Iterator $data
+     * @param        mixed $expected
+     */
+    public function testIterators(\Iterator $data, $expected): void
+    {
+        // When
+        $result = Reduce::toLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForIterators(): array
+    {
+        $iter = fn (array $data) => new ArrayIteratorFixture($data);
+
+        return [
+            [
+                $iter([0]),
+                0,
+            ],
+            [
+                $iter([null]),
+                null,
+            ],
+            [
+                $iter(['']),
+                '',
+            ],
+            [
+                $iter(['', null]),
+                null,
+            ],
+            [
+                $iter([3, 2]),
+                2,
+            ],
+            [
+                $iter([1, 2, 3]),
+                3,
+            ],
+            [
+                $iter([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                3.1,
+            ],
+            [
+                $iter([[1], '2', 3]),
+                3,
+            ],
+            [
+                $iter([false, [1], '2', 3]),
+                3,
+            ],
+            [
+                $iter([true, [1], '2', 3]),
+                3,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTraversables
+     * @param        \Traversable $data
+     * @param        mixed $expected
+     */
+    public function testTraversables(\Traversable $data, $expected): void
+    {
+        // When
+        $result = Reduce::toLast($data);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForTraversables(): array
+    {
+        $trav = fn (array $data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                $trav([0]),
+                0,
+            ],
+            [
+                $trav([null]),
+                null,
+            ],
+            [
+                $trav(['']),
+                '',
+            ],
+            [
+                $trav(['', null]),
+                null,
+            ],
+            [
+                $trav([3, 2]),
+                2,
+            ],
+            [
+                $trav([1, 2, 3]),
+                3,
+            ],
+            [
+                $trav([1.1, 1.1, 2.1, 2.1, 3.1, 3.1]),
+                3.1,
+            ],
+            [
+                $trav([[1], '2', 3]),
+                3,
+            ],
+            [
+                $trav([false, [1], '2', 3]),
+                3,
+            ],
+            [
+                $trav([true, [1], '2', 3]),
+                3,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForEmptyIterable
+     * @param iterable $data
+     * @return void
+     */
+    public function testErrorOnEmptyCollection(iterable $data): void
+    {
+        $this->expectException(\LengthException::class);
+        Reduce::toLast($data);
+    }
+}

--- a/tests/Reduce/ToMaxTest.php
+++ b/tests/Reduce/ToMaxTest.php
@@ -15,12 +15,13 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMax array
      * @dataProvider dataProviderForArray
      * @param        array $data
+     * @param        callable|null $comparator
      * @param        int|float $expected
      */
-    public function testArray(array $data, $expected)
+    public function testArray(array $data, ?callable $comparator, $expected)
     {
         // When
-        $result = Reduce::toMax($data);
+        $result = Reduce::toMax($data, $comparator);
 
         // Then
         $this->assertSame($expected, $result);
@@ -31,135 +32,523 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 [],
-                null
+                null,
+                null,
+            ],
+            [
+                [],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                null,
+            ],
+            [
+                [],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                null,
             ],
             [
                 [0],
-                0
+                null,
+                0,
+            ],
+            [
+                [0],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                0,
+            ],
+            [
+                [0],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                0,
             ],
             [
                 [INF],
-                INF
+                null,
+                INF,
+            ],
+            [
+                [INF],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                [INF],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 [-INF],
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                [-INF],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                [-INF],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 [INF, -INF],
-                INF
+                null,
+                INF,
+            ],
+            [
+                [INF, -INF],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                [INF, -INF],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 [INF, -INF, 10, -1],
-                INF
+                null,
+                INF,
+            ],
+            [
+                [INF, -INF, 10, -1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                [INF, -INF, 10, -1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 [1, 2, 3],
-                3
+                null,
+                3,
+            ],
+            [
+                [1, 2, 3],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                [1, 2, 3],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 [3, 2, 1],
-                3
+                null,
+                3,
+            ],
+            [
+                [3, 2, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                [3, 2, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 [2, 3, 1],
-                3
+                null,
+                3,
+            ],
+            [
+                [2, 3, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                [2, 3, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 [1, 2.1],
-                2.1
+                null,
+                2.1,
+            ],
+            [
+                [1, 2.1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.1,
+            ],
+            [
+                [1, 2.1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 [2.1, 1],
-                2.1
+                null,
+                2.1,
+            ],
+            [
+                [2.1, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.1,
+            ],
+            [
+                [2.1, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 [2, 1.1],
-                2
+                null,
+                2,
+            ],
+            [
+                [2, 1.1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2,
+            ],
+            [
+                [2, 1.1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 [2.2, 1.1],
-                2.2
+                null,
+                2.2,
+            ],
+            [
+                [2.2, 1.1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.2,
+            ],
+            [
+                [2.2, 1.1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 [1.1, 2.2],
-                2.2
+                null,
+                2.2,
+            ],
+            [
+                [1.1, 2.2],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.2,
+            ],
+            [
+                [1.1, 2.2],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 ['a', 'b', 'c'],
-                'c'
+                null,
+                'c',
+            ],
+            [
+                ['a', 'b', 'c'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                ['a', 'b', 'c'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 ['b', 'c', 'a'],
-                'c'
+                null,
+                'c',
+            ],
+            [
+                ['b', 'c', 'a'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                ['b', 'c', 'a'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 ['c', 'b', 'a'],
-                'c'
+                null,
+                'c',
+            ],
+            [
+                ['c', 'b', 'a'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                ['c', 'b', 'a'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 ['ab', 'ba', 'b'],
-                'ba'
+                null,
+                'ba',
+            ],
+            [
+                ['ab', 'ba', 'b'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ba',
+            ],
+            [
+                ['ab', 'ba', 'b'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ab',
             ],
             [
                 ['ba', 'b', 'ab'],
-                'ba'
+                null,
+                'ba',
+            ],
+            [
+                ['ba', 'b', 'ab'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ba',
+            ],
+            [
+                ['ba', 'b', 'ab'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ab',
             ],
             [
                 [[]],
-                []
+                null,
+                [],
+            ],
+            [
+                [[]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [[]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 [[2]],
-                [2]
+                null,
+                [2],
+            ],
+            [
+                [[2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                [[2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 [[], []],
-                []
+                null,
+                [],
+            ],
+            [
+                [[], []],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [[], []],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 [[], [2]],
-                [2]
+                null,
+                [2],
+            ],
+            [
+                [[], [2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                [[], [2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 [[2], []],
-                [2]
+                null,
+                [2],
+            ],
+            [
+                [[2], []],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                [[2], []],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 [[], [null]],
-                [null]
+                null,
+                [null],
+            ],
+            [
+                [[], [null]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                [[], [null]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 [[null], []],
-                [null]
+                null,
+                [null],
+            ],
+            [
+                [[null], []],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                [[null], []],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 [[null], [null]],
-                [null]
+                null,
+                [null],
+            ],
+            [
+                [[null], [null]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                [[null], [null]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 [[1, 2], [2]],
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                [[1, 2], [2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                [[1, 2], [2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 [[3, 2], [2]],
-                [3, 2]
+                null,
+                [3, 2],
+            ],
+            [
+                [[3, 2], [2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [3, 2],
+            ],
+            [
+                [[3, 2], [2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 [[1, 2], [2, 1]],
-                [2, 1]
+                null,
+                [2, 1],
+            ],
+            [
+                [[1, 2], [2, 1]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1],
+            ],
+            [
+                [[1, 2], [2, 1]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 [[2, 1], [1, 2]],
-                [2, 1]
+                null,
+                [2, 1],
+            ],
+            [
+                [[2, 1], [1, 2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1],
+            ],
+            [
+                [[2, 1], [1, 2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 [['a'], ['b']],
-                ['b']
+                null,
+                ['b'],
+            ],
+            [
+                [['a'], ['b']],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['b'],
+            ],
+            [
+                [['a'], ['b']],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['a'],
             ],
             [
                 [['a', 'a'], ['b']],
-                ['a', 'a']
+                null,
+                ['a', 'a'],
+            ],
+            [
+                [['a', 'a'], ['b']],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['a', 'a'],
+            ],
+            [
+                [['a', 'a'], ['b']],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['b'],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                null,
+                [2, 1, 3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1, 3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2, 3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [1, 2, 3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [2, 0, 3],
             ],
         ];
     }
@@ -168,12 +557,13 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMax generators
      * @dataProvider dataProviderForGenerators
      * @param        \Generator $data
+     * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testGenerators(\Generator $data, $expected)
+    public function testGenerators(\Generator $data, ?callable $comparator, $expected)
     {
         // When
-        $result = Reduce::toMax($data);
+        $result = Reduce::toMax($data, $comparator);
 
         // Then
         $this->assertSame($expected, $result);
@@ -188,150 +578,523 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $gen([]),
-                null
+                null,
+                null,
+            ],
+            [
+                $gen([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                null,
+            ],
+            [
+                $gen([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                null,
             ],
             [
                 $gen([0]),
-                0
+                null,
+                0,
+            ],
+            [
+                $gen([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                0,
+            ],
+            [
+                $gen([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                0,
             ],
             [
                 $gen([INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $gen([INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $gen([INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $gen([-INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $gen([-INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $gen([-INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $gen([INF, -INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $gen([INF, -INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $gen([INF, -INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $gen([INF, -INF, 10, -1]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $gen([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $gen([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $gen([1, 2, 3]),
-                3
+                null,
+                3,
+            ],
+            [
+                $gen([1, 2, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $gen([1, 2, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $gen([3, 2, 1]),
-                3
+                null,
+                3,
+            ],
+            [
+                $gen([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $gen([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $gen([2, 3, 1]),
-                3
+                null,
+                3,
+            ],
+            [
+                $gen([2, 3, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $gen([2, 3, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $gen([1, 2.1]),
-                2.1
+                null,
+                2.1,
+            ],
+            [
+                $gen([1, 2.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.1,
+            ],
+            [
+                $gen([1, 2.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $gen([2.1, 1]),
-                2.1
+                null,
+                2.1,
+            ],
+            [
+                $gen([2.1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.1,
+            ],
+            [
+                $gen([2.1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $gen([2, 1.1]),
-                2
+                null,
+                2,
+            ],
+            [
+                $gen([2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2,
+            ],
+            [
+                $gen([2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $gen([2.2, 1.1]),
-                2.2
+                null,
+                2.2,
+            ],
+            [
+                $gen([2.2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.2,
+            ],
+            [
+                $gen([2.2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $gen([1.1, 2.2]),
-                2.2
+                null,
+                2.2,
+            ],
+            [
+                $gen([1.1, 2.2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.2,
+            ],
+            [
+                $gen([1.1, 2.2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $gen(['a', 'b', 'c']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $gen(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $gen(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $gen(['b', 'c', 'a']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $gen(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $gen(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $gen(['c', 'b', 'a']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $gen(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $gen(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $gen(['ab', 'ba', 'b']),
-                'ba'
+                null,
+                'ba',
+            ],
+            [
+                $gen(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ba',
+            ],
+            [
+                $gen(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ab',
             ],
             [
                 $gen(['ba', 'b', 'ab']),
-                'ba'
+                null,
+                'ba',
+            ],
+            [
+                $gen(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ba',
+            ],
+            [
+                $gen(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ab',
             ],
             [
                 $gen([[]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $gen([[]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $gen([[]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $gen([[2]]),
-                [2]
+                null,
+                [2],
             ],
             [
-                $gen([[
-
-                ], []]),
-                []
+                $gen([[2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
             ],
             [
-                $gen([[
-
-                ], [2]]),
-                [2]
+                $gen([[2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
-                $gen([[2
-                ], []]),
-                [2]
+                $gen([[], []]),
+                null,
+                [],
             ],
             [
-                $gen([[
-
-                ], [null]]),
-                [null]
+                $gen([[], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
             ],
             [
-                $gen([[null
-                ], []]),
-                [null]
+                $gen([[], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
-                $gen([[null
-                ], [null]]),
-                [null]
+                $gen([[], [2]]),
+                null,
+                [2],
             ],
             [
-                $gen([[1, 2
-                ], [2]]),
-                [1, 2]
+                $gen([[], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
             ],
             [
-                $gen([[3, 2
-                ], [2]]),
-                [3, 2]
+                $gen([[], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
-                $gen([[1, 2
-                ], [2, 1]]),
-                [2, 1]
+                $gen([[2], []]),
+                null,
+                [2],
             ],
             [
-                $gen([[2, 1
-                ], [1, 2]]),
-                [2, 1]
+                $gen([[2], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
             ],
             [
-                $gen([['a'
-                ], ['b']]),
-                ['b']
+                $gen([[2], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
-                $gen([['a', 'a'
-                ], ['b']]),
-                ['a', 'a']
+                $gen([[], [null]]),
+                null,
+                [null],
+            ],
+            [
+                $gen([[], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $gen([[], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
+            ],
+            [
+                $gen([[null], []]),
+                null,
+                [null],
+            ],
+            [
+                $gen([[null], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $gen([[null], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
+            ],
+            [
+                $gen([[null], [null]]),
+                null,
+                [null],
+            ],
+            [
+                $gen([[null], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $gen([[null], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
+            ],
+            [
+                $gen([[1, 2], [2]]),
+                null,
+                [1, 2],
+            ],
+            [
+                $gen([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $gen([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
+            ],
+            [
+                $gen([[3, 2], [2]]),
+                null,
+                [3, 2],
+            ],
+            [
+                $gen([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [3, 2],
+            ],
+            [
+                $gen([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
+            ],
+            [
+                $gen([[1, 2], [2, 1]]),
+                null,
+                [2, 1],
+            ],
+            [
+                $gen([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1],
+            ],
+            [
+                $gen([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
+            ],
+            [
+                $gen([[2, 1], [1, 2]]),
+                null,
+                [2, 1],
+            ],
+            [
+                $gen([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1],
+            ],
+            [
+                $gen([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
+            ],
+            [
+                $gen([['a'], ['b']]),
+                null,
+                ['b'],
+            ],
+            [
+                $gen([['a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['b'],
+            ],
+            [
+                $gen([['a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['a'],
+            ],
+            [
+                $gen([['a', 'a'], ['b']]),
+                null,
+                ['a', 'a'],
+            ],
+            [
+                $gen([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['a', 'a'],
+            ],
+            [
+                $gen([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['b'],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [2, 1, 3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1, 3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2, 3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [1, 2, 3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [2, 0, 3],
             ],
         ];
     }
@@ -340,12 +1103,13 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMax iterators
      * @dataProvider dataProviderForIterators
      * @param        \Generator $data
+     * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testIterators(\Iterator $data, $expected)
+    public function testIterators(\Iterator $data, ?callable $comparator, $expected)
     {
         // When
-        $result = Reduce::toMax($data);
+        $result = Reduce::toMax($data, $comparator);
 
         // Then
         $this->assertSame($expected, $result);
@@ -360,135 +1124,523 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $iter([]),
-                null
+                null,
+                null,
+            ],
+            [
+                $iter([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                null,
+            ],
+            [
+                $iter([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                null,
             ],
             [
                 $iter([0]),
-                0
+                null,
+                0,
+            ],
+            [
+                $iter([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                0,
+            ],
+            [
+                $iter([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                0,
             ],
             [
                 $iter([INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $iter([INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $iter([INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $iter([-INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $iter([-INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $iter([-INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $iter([INF, -INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $iter([INF, -INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $iter([INF, -INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $iter([INF, -INF, 10, -1]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $iter([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $iter([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $iter([1, 2, 3]),
-                3
+                null,
+                3,
+            ],
+            [
+                $iter([1, 2, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $iter([1, 2, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $iter([3, 2, 1]),
-                3
+                null,
+                3,
+            ],
+            [
+                $iter([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $iter([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $iter([2, 3, 1]),
-                3
+                null,
+                3,
+            ],
+            [
+                $iter([2, 3, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $iter([2, 3, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $iter([1, 2.1]),
-                2.1
+                null,
+                2.1,
+            ],
+            [
+                $iter([1, 2.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.1,
+            ],
+            [
+                $iter([1, 2.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $iter([2.1, 1]),
-                2.1
+                null,
+                2.1,
+            ],
+            [
+                $iter([2.1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.1,
+            ],
+            [
+                $iter([2.1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $iter([2, 1.1]),
-                2
+                null,
+                2,
+            ],
+            [
+                $iter([2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2,
+            ],
+            [
+                $iter([2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $iter([2.2, 1.1]),
-                2.2
+                null,
+                2.2,
+            ],
+            [
+                $iter([2.2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.2,
+            ],
+            [
+                $iter([2.2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $iter([1.1, 2.2]),
-                2.2
+                null,
+                2.2,
+            ],
+            [
+                $iter([1.1, 2.2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.2,
+            ],
+            [
+                $iter([1.1, 2.2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $iter(['a', 'b', 'c']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $iter(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $iter(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $iter(['b', 'c', 'a']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $iter(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $iter(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $iter(['c', 'b', 'a']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $iter(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $iter(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $iter(['ab', 'ba', 'b']),
-                'ba'
+                null,
+                'ba',
+            ],
+            [
+                $iter(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ba',
+            ],
+            [
+                $iter(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ab',
             ],
             [
                 $iter(['ba', 'b', 'ab']),
-                'ba'
+                null,
+                'ba',
+            ],
+            [
+                $iter(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ba',
+            ],
+            [
+                $iter(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ab',
             ],
             [
                 $iter([[]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $iter([[]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([[]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $iter([[2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $iter([[2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $iter([[2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $iter([[], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $iter([[], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([[], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $iter([[], [2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $iter([[], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $iter([[], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $iter([[2], []]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $iter([[2], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $iter([[2], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $iter([[], [null]]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $iter([[], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $iter([[], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $iter([[null], []]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $iter([[null], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $iter([[null], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $iter([[null], [null]]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $iter([[null], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $iter([[null], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $iter([[1, 2], [2]]),
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                $iter([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $iter([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $iter([[3, 2], [2]]),
-                [3, 2]
+                null,
+                [3, 2],
+            ],
+            [
+                $iter([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [3, 2],
+            ],
+            [
+                $iter([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $iter([[1, 2], [2, 1]]),
-                [2, 1]
+                null,
+                [2, 1],
+            ],
+            [
+                $iter([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1],
+            ],
+            [
+                $iter([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 $iter([[2, 1], [1, 2]]),
-                [2, 1]
+                null,
+                [2, 1],
+            ],
+            [
+                $iter([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1],
+            ],
+            [
+                $iter([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 $iter([['a'], ['b']]),
-                ['b']
+                null,
+                ['b'],
+            ],
+            [
+                $iter([['a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['b'],
+            ],
+            [
+                $iter([['a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['a'],
             ],
             [
                 $iter([['a', 'a'], ['b']]),
-                ['a', 'a']
+                null,
+                ['a', 'a'],
+            ],
+            [
+                $iter([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['a', 'a'],
+            ],
+            [
+                $iter([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['b'],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [2, 1, 3],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1, 3],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2, 3],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [1, 2, 3],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [2, 0, 3],
             ],
         ];
     }
@@ -497,12 +1649,13 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMax traversables
      * @dataProvider dataProviderForTraversables
      * @param        \Traversable $data
+     * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testTraversables(\Traversable $data, $expected)
+    public function testTraversables(\Traversable $data, ?callable $comparator, $expected)
     {
         // When
-        $result = Reduce::toMax($data);
+        $result = Reduce::toMax($data, $comparator);
 
         // Then
         $this->assertSame($expected, $result);
@@ -517,135 +1670,523 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $trav([]),
-                null
+                null,
+                null,
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                null,
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                null,
             ],
             [
                 $trav([0]),
-                0
+                null,
+                0,
+            ],
+            [
+                $trav([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                0,
+            ],
+            [
+                $trav([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                0,
             ],
             [
                 $trav([INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $trav([INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $trav([INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $trav([-INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $trav([-INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $trav([-INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $trav([INF, -INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $trav([INF, -INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $trav([INF, -INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $trav([INF, -INF, 10, -1]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $trav([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $trav([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $trav([1, 2, 3]),
-                3
+                null,
+                3,
+            ],
+            [
+                $trav([1, 2, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $trav([1, 2, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $trav([3, 2, 1]),
-                3
+                null,
+                3,
+            ],
+            [
+                $trav([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $trav([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $trav([2, 3, 1]),
-                3
+                null,
+                3,
+            ],
+            [
+                $trav([2, 3, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                3,
+            ],
+            [
+                $trav([2, 3, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $trav([1, 2.1]),
-                2.1
+                null,
+                2.1,
+            ],
+            [
+                $trav([1, 2.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.1,
+            ],
+            [
+                $trav([1, 2.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $trav([2.1, 1]),
-                2.1
+                null,
+                2.1,
+            ],
+            [
+                $trav([2.1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.1,
+            ],
+            [
+                $trav([2.1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1,
             ],
             [
                 $trav([2, 1.1]),
-                2
+                null,
+                2,
+            ],
+            [
+                $trav([2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2,
+            ],
+            [
+                $trav([2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $trav([2.2, 1.1]),
-                2.2
+                null,
+                2.2,
+            ],
+            [
+                $trav([2.2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.2,
+            ],
+            [
+                $trav([2.2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $trav([1.1, 2.2]),
-                2.2
+                null,
+                2.2,
+            ],
+            [
+                $trav([1.1, 2.2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                2.2,
+            ],
+            [
+                $trav([1.1, 2.2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                1.1,
             ],
             [
                 $trav(['a', 'b', 'c']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $trav(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $trav(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $trav(['b', 'c', 'a']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $trav(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $trav(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $trav(['c', 'b', 'a']),
-                'c'
+                null,
+                'c',
+            ],
+            [
+                $trav(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'c',
+            ],
+            [
+                $trav(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'a',
             ],
             [
                 $trav(['ab', 'ba', 'b']),
-                'ba'
+                null,
+                'ba',
+            ],
+            [
+                $trav(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ba',
+            ],
+            [
+                $trav(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ab',
             ],
             [
                 $trav(['ba', 'b', 'ab']),
-                'ba'
+                null,
+                'ba',
+            ],
+            [
+                $trav(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ba',
+            ],
+            [
+                $trav(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ab',
             ],
             [
                 $trav([[]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $trav([[]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([[]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $trav([[2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $trav([[2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $trav([[2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $trav([[], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $trav([[], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([[], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $trav([[], [2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $trav([[], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $trav([[], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $trav([[2], []]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $trav([[2], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $trav([[2], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $trav([[], [null]]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $trav([[], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $trav([[], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $trav([[null], []]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $trav([[null], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $trav([[null], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $trav([[null], [null]]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $trav([[null], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $trav([[null], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $trav([[1, 2], [2]]),
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                $trav([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $trav([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $trav([[3, 2], [2]]),
-                [3, 2]
+                null,
+                [3, 2],
+            ],
+            [
+                $trav([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [3, 2],
+            ],
+            [
+                $trav([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $trav([[1, 2], [2, 1]]),
-                [2, 1]
+                null,
+                [2, 1],
+            ],
+            [
+                $trav([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1],
+            ],
+            [
+                $trav([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 $trav([[2, 1], [1, 2]]),
-                [2, 1]
+                null,
+                [2, 1],
+            ],
+            [
+                $trav([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1],
+            ],
+            [
+                $trav([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 $trav([['a'], ['b']]),
-                ['b']
+                null,
+                ['b'],
+            ],
+            [
+                $trav([['a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['b'],
+            ],
+            [
+                $trav([['a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['a'],
             ],
             [
                 $trav([['a', 'a'], ['b']]),
-                ['a', 'a']
+                null,
+                ['a', 'a'],
+            ],
+            [
+                $trav([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['a', 'a'],
+            ],
+            [
+                $trav([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['b'],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [2, 1, 3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2, 1, 3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2, 3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [1, 2, 3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [2, 0, 3],
             ],
         ];
     }

--- a/tests/Reduce/ToMaxTest.php
+++ b/tests/Reduce/ToMaxTest.php
@@ -15,13 +15,13 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMax array
      * @dataProvider dataProviderForArray
      * @param        array $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        int|float $expected
      */
-    public function testArray(array $data, ?callable $comparator, $expected): void
+    public function testArray(array $data, ?callable $compareBy, $expected): void
     {
         // When
-        $result = Reduce::toMax($data, $comparator);
+        $result = Reduce::toMax($data, $compareBy);
 
         // Then
         $this->assertSame($expected, $result);
@@ -472,13 +472,13 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMax generators
      * @dataProvider dataProviderForGenerators
      * @param        \Generator $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        mixed $expected
      */
-    public function testGenerators(\Generator $data, ?callable $comparator, $expected): void
+    public function testGenerators(\Generator $data, ?callable $compareBy, $expected): void
     {
         // When
-        $result = Reduce::toMax($data, $comparator);
+        $result = Reduce::toMax($data, $compareBy);
 
         // Then
         $this->assertSame($expected, $result);
@@ -933,13 +933,13 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMax iterators
      * @dataProvider dataProviderForIterators
      * @param        \Generator $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        mixed $expected
      */
-    public function testIterators(\Iterator $data, ?callable $comparator, $expected): void
+    public function testIterators(\Iterator $data, ?callable $compareBy, $expected): void
     {
         // When
-        $result = Reduce::toMax($data, $comparator);
+        $result = Reduce::toMax($data, $compareBy);
 
         // Then
         $this->assertSame($expected, $result);
@@ -1394,13 +1394,13 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMax traversables
      * @dataProvider dataProviderForTraversables
      * @param        \Traversable $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        mixed $expected
      */
-    public function testTraversables(\Traversable $data, ?callable $comparator, $expected): void
+    public function testTraversables(\Traversable $data, ?callable $compareBy, $expected): void
     {
         // When
-        $result = Reduce::toMax($data, $comparator);
+        $result = Reduce::toMax($data, $compareBy);
 
         // Then
         $this->assertSame($expected, $result);
@@ -1847,6 +1847,60 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
                 fn ($item) => -$item[1],
                 [2, 0, 3],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForUsingClassMethodToCompare
+     * @param iterable $data
+     * @param callable|null $compareBy
+     * @param $expected
+     * @return void
+     */
+    public function testUsingClassMethodToCompare(iterable $data, ?callable $compareBy, $expected): void
+    {
+        // When
+        $result = Reduce::toMax($data, $compareBy);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForUsingClassMethodToCompare(): array
+    {
+        $helper = new class () {
+            public function direct(int $value): int
+            {
+                return $value;
+            }
+
+            public function reverse(int $value): int
+            {
+                return -$value;
+            }
+        };
+
+        return [
+            [
+                [1, 3, 2, 5, 0],
+                fn ($item) => $helper->direct($item),
+                5,
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                fn ($item) => $helper->reverse($item),
+                0,
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                [$helper, 'direct'],
+                5,
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                [$helper, 'reverse'],
+                0,
             ],
         ];
     }

--- a/tests/Reduce/ToMaxTest.php
+++ b/tests/Reduce/ToMaxTest.php
@@ -37,12 +37,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 null,
             ],
             [
                 [],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 null,
             ],
             [
@@ -52,12 +52,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [0],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 0,
             ],
             [
                 [0],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 0,
             ],
             [
@@ -67,12 +67,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [INF],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 [INF],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -82,12 +82,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [-INF],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 [-INF],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -97,12 +97,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [INF, -INF],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 [INF, -INF],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -112,12 +112,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [INF, -INF, 10, -1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 [INF, -INF, 10, -1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -127,12 +127,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [1, 2, 3],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 [1, 2, 3],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -142,12 +142,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [3, 2, 1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 [3, 2, 1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -157,12 +157,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2, 3, 1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 [2, 3, 1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -172,12 +172,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [1, 2.1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.1,
             ],
             [
                 [1, 2.1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -187,12 +187,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2.1, 1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.1,
             ],
             [
                 [2.1, 1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -202,12 +202,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2, 1.1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2,
             ],
             [
                 [2, 1.1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -217,12 +217,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2.2, 1.1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.2,
             ],
             [
                 [2.2, 1.1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -232,12 +232,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [1.1, 2.2],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.2,
             ],
             [
                 [1.1, 2.2],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -247,12 +247,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['a', 'b', 'c'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 ['a', 'b', 'c'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -262,12 +262,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['b', 'c', 'a'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 ['b', 'c', 'a'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -277,12 +277,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['c', 'b', 'a'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 ['c', 'b', 'a'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -292,13 +292,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['ab', 'ba', 'b'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ba',
-            ],
-            [
-                ['ab', 'ba', 'b'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ab',
             ],
             [
                 ['ba', 'b', 'ab'],
@@ -307,13 +302,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['ba', 'b', 'ab'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ba',
-            ],
-            [
-                ['ba', 'b', 'ab'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ab',
             ],
             [
                 [[]],
@@ -322,12 +312,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                [[]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -337,12 +322,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [2],
-            ],
-            [
-                [[2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
@@ -352,12 +332,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[], []],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                [[], []],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -367,13 +342,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[], [2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
-            ],
-            [
-                [[], [2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 [[2], []],
@@ -382,28 +352,18 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[2], []],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
-                [[2], []],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
-            ],
-            [
                 [[], [null]],
                 null,
                 [null],
             ],
             [
                 [[], [null]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null],
-            ],
-            [
-                [[], [null]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 [[null], []],
@@ -412,13 +372,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[null], []],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null],
-            ],
-            [
-                [[null], []],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 [[null], [null]],
@@ -427,12 +382,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[null], [null]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [null],
-            ],
-            [
-                [[null], [null]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [null],
             ],
             [
@@ -442,13 +392,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[1, 2], [2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                [[1, 2], [2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 [[3, 2], [2]],
@@ -457,28 +402,18 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[3, 2], [2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [3, 2],
             ],
             [
-                [[3, 2], [2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
-            ],
-            [
                 [[1, 2], [2, 1]],
                 null,
                 [2, 1],
             ],
             [
                 [[1, 2], [2, 1]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1],
-            ],
-            [
-                [[1, 2], [2, 1]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 [[2, 1], [1, 2]],
@@ -487,13 +422,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[2, 1], [1, 2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1],
-            ],
-            [
-                [[2, 1], [1, 2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 [['a'], ['b']],
@@ -502,13 +432,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [['a'], ['b']],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['b'],
-            ],
-            [
-                [['a'], ['b']],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['a'],
             ],
             [
                 [['a', 'a'], ['b']],
@@ -517,13 +442,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [['a', 'a'], ['b']],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['a', 'a'],
-            ],
-            [
-                [['a', 'a'], ['b']],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['b'],
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
@@ -532,22 +452,17 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1, 3],
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item[1],
                 [1, 2, 3],
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
-                [1, 2, 3],
-            ],
-            [
-                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [2, 0, 3],
             ],
         ];
@@ -583,12 +498,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 null,
             ],
             [
                 $gen([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 null,
             ],
             [
@@ -598,12 +513,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 0,
             ],
             [
                 $gen([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 0,
             ],
             [
@@ -613,12 +528,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $gen([INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -628,12 +543,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([-INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $gen([-INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -643,12 +558,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([INF, -INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $gen([INF, -INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -658,12 +573,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $gen([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -673,12 +588,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([1, 2, 3]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $gen([1, 2, 3]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -688,12 +603,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $gen([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -703,12 +618,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2, 3, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $gen([2, 3, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -718,12 +633,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([1, 2.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.1,
             ],
             [
                 $gen([1, 2.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -733,12 +648,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2.1, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.1,
             ],
             [
                 $gen([2.1, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -748,12 +663,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2,
             ],
             [
                 $gen([2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -763,12 +678,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2.2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.2,
             ],
             [
                 $gen([2.2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -778,12 +693,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([1.1, 2.2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.2,
             ],
             [
                 $gen([1.1, 2.2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -793,12 +708,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $gen(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -808,12 +723,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $gen(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -823,12 +738,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $gen(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -838,13 +753,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ba',
-            ],
-            [
-                $gen(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ab',
             ],
             [
                 $gen(['ba', 'b', 'ab']),
@@ -853,13 +763,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ba',
-            ],
-            [
-                $gen(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ab',
             ],
             [
                 $gen([[]]),
@@ -868,12 +773,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $gen([[]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -883,12 +783,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [2],
-            ],
-            [
-                $gen([[2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
@@ -898,12 +793,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $gen([[], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -913,13 +803,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
-            ],
-            [
-                $gen([[], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $gen([[2], []]),
@@ -928,28 +813,18 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[2], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
-                $gen([[2], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
-            ],
-            [
                 $gen([[], [null]]),
                 null,
                 [null],
             ],
             [
                 $gen([[], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null],
-            ],
-            [
-                $gen([[], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $gen([[null], []]),
@@ -958,13 +833,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[null], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null],
-            ],
-            [
-                $gen([[null], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $gen([[null], [null]]),
@@ -973,12 +843,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[null], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [null],
-            ],
-            [
-                $gen([[null], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [null],
             ],
             [
@@ -988,13 +853,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $gen([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $gen([[3, 2], [2]]),
@@ -1003,28 +863,18 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [3, 2],
             ],
             [
-                $gen([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
-            ],
-            [
                 $gen([[1, 2], [2, 1]]),
                 null,
                 [2, 1],
             ],
             [
                 $gen([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1],
-            ],
-            [
-                $gen([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $gen([[2, 1], [1, 2]]),
@@ -1033,13 +883,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1],
-            ],
-            [
-                $gen([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $gen([['a'], ['b']]),
@@ -1048,13 +893,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([['a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['b'],
-            ],
-            [
-                $gen([['a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['a'],
             ],
             [
                 $gen([['a', 'a'], ['b']]),
@@ -1063,13 +903,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['a', 'a'],
-            ],
-            [
-                $gen([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['b'],
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
@@ -1078,22 +913,17 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1, 3],
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item[1],
                 [1, 2, 3],
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
-                [1, 2, 3],
-            ],
-            [
-                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [2, 0, 3],
             ],
         ];
@@ -1129,12 +959,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 null,
             ],
             [
                 $iter([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 null,
             ],
             [
@@ -1144,12 +974,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 0,
             ],
             [
                 $iter([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 0,
             ],
             [
@@ -1159,12 +989,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $iter([INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -1174,12 +1004,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([-INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $iter([-INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -1189,12 +1019,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([INF, -INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $iter([INF, -INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -1204,12 +1034,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $iter([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -1219,12 +1049,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([1, 2, 3]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $iter([1, 2, 3]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1234,12 +1064,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $iter([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1249,12 +1079,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([2, 3, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $iter([2, 3, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1264,12 +1094,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([1, 2.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.1,
             ],
             [
                 $iter([1, 2.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1279,12 +1109,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([2.1, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.1,
             ],
             [
                 $iter([2.1, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1294,12 +1124,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2,
             ],
             [
                 $iter([2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -1309,12 +1139,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([2.2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.2,
             ],
             [
                 $iter([2.2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -1324,12 +1154,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([1.1, 2.2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.2,
             ],
             [
                 $iter([1.1, 2.2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -1339,12 +1169,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $iter(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -1354,12 +1184,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $iter(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -1369,12 +1199,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $iter(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -1384,13 +1214,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ba',
-            ],
-            [
-                $iter(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ab',
             ],
             [
                 $iter(['ba', 'b', 'ab']),
@@ -1399,13 +1224,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ba',
-            ],
-            [
-                $iter(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ab',
             ],
             [
                 $iter([[]]),
@@ -1414,12 +1234,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $iter([[]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -1429,12 +1244,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [2],
-            ],
-            [
-                $iter([[2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
@@ -1444,12 +1254,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $iter([[], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -1459,13 +1264,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
-            ],
-            [
-                $iter([[], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $iter([[2], []]),
@@ -1474,28 +1274,18 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[2], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
-                $iter([[2], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
-            ],
-            [
                 $iter([[], [null]]),
                 null,
                 [null],
             ],
             [
                 $iter([[], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null],
-            ],
-            [
-                $iter([[], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $iter([[null], []]),
@@ -1504,13 +1294,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[null], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null],
-            ],
-            [
-                $iter([[null], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $iter([[null], [null]]),
@@ -1519,12 +1304,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[null], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [null],
-            ],
-            [
-                $iter([[null], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [null],
             ],
             [
@@ -1534,13 +1314,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $iter([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $iter([[3, 2], [2]]),
@@ -1549,28 +1324,18 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [3, 2],
             ],
             [
-                $iter([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
-            ],
-            [
                 $iter([[1, 2], [2, 1]]),
                 null,
                 [2, 1],
             ],
             [
                 $iter([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1],
-            ],
-            [
-                $iter([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $iter([[2, 1], [1, 2]]),
@@ -1579,13 +1344,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1],
-            ],
-            [
-                $iter([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $iter([['a'], ['b']]),
@@ -1594,13 +1354,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([['a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['b'],
-            ],
-            [
-                $iter([['a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['a'],
             ],
             [
                 $iter([['a', 'a'], ['b']]),
@@ -1609,13 +1364,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['a', 'a'],
-            ],
-            [
-                $iter([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['b'],
             ],
             [
                 $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
@@ -1624,22 +1374,17 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1, 3],
             ],
             [
                 $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item[1],
                 [1, 2, 3],
             ],
             [
                 $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
-                [1, 2, 3],
-            ],
-            [
-                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [2, 0, 3],
             ],
         ];
@@ -1675,12 +1420,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 null,
             ],
             [
                 $trav([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 null,
             ],
             [
@@ -1690,12 +1435,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 0,
             ],
             [
                 $trav([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 0,
             ],
             [
@@ -1705,12 +1450,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $trav([INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -1720,12 +1465,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([-INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $trav([-INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -1735,12 +1480,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([INF, -INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $trav([INF, -INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -1750,12 +1495,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $trav([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -1765,12 +1510,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([1, 2, 3]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $trav([1, 2, 3]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1780,12 +1525,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $trav([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1795,12 +1540,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2, 3, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 3,
             ],
             [
                 $trav([2, 3, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1810,12 +1555,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([1, 2.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.1,
             ],
             [
                 $trav([1, 2.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1825,12 +1570,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2.1, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.1,
             ],
             [
                 $trav([2.1, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1,
             ],
             [
@@ -1840,12 +1585,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2,
             ],
             [
                 $trav([2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -1855,12 +1600,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2.2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.2,
             ],
             [
                 $trav([2.2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -1870,12 +1615,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([1.1, 2.2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 2.2,
             ],
             [
                 $trav([1.1, 2.2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 1.1,
             ],
             [
@@ -1885,12 +1630,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $trav(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -1900,12 +1645,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $trav(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -1915,12 +1660,12 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'c',
             ],
             [
                 $trav(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'a',
             ],
             [
@@ -1930,12 +1675,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                'ba',
-            ],
-            [
-                $trav(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'ab',
             ],
             [
@@ -1945,27 +1685,17 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ba',
             ],
             [
-                $trav(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ab',
-            ],
-            [
                 $trav([[]]),
                 null,
                 [],
             ],
             [
                 $trav([[]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $trav([[]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -1975,12 +1705,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [2],
-            ],
-            [
-                $trav([[2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
@@ -1990,12 +1715,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $trav([[], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -2005,13 +1725,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
-            ],
-            [
-                $trav([[], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $trav([[2], []]),
@@ -2020,28 +1735,18 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[2], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
-                $trav([[2], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
-            ],
-            [
                 $trav([[], [null]]),
                 null,
                 [null],
             ],
             [
                 $trav([[], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null],
-            ],
-            [
-                $trav([[], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $trav([[null], []]),
@@ -2050,13 +1755,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[null], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null],
-            ],
-            [
-                $trav([[null], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [],
             ],
             [
                 $trav([[null], [null]]),
@@ -2065,12 +1765,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[null], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [null],
-            ],
-            [
-                $trav([[null], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [null],
             ],
             [
@@ -2080,13 +1775,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $trav([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $trav([[3, 2], [2]]),
@@ -2095,28 +1785,18 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [3, 2],
             ],
             [
-                $trav([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
-            ],
-            [
                 $trav([[1, 2], [2, 1]]),
                 null,
                 [2, 1],
             ],
             [
                 $trav([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1],
-            ],
-            [
-                $trav([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $trav([[2, 1], [1, 2]]),
@@ -2125,13 +1805,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1],
-            ],
-            [
-                $trav([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $trav([['a'], ['b']]),
@@ -2140,13 +1815,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([['a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['b'],
-            ],
-            [
-                $trav([['a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['a'],
             ],
             [
                 $trav([['a', 'a'], ['b']]),
@@ -2155,13 +1825,8 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['a', 'a'],
-            ],
-            [
-                $trav([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['b'],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
@@ -2170,22 +1835,17 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2, 1, 3],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item[1],
                 [1, 2, 3],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
-                [1, 2, 3],
-            ],
-            [
-                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [2, 0, 3],
             ],
         ];

--- a/tests/Reduce/ToMaxTest.php
+++ b/tests/Reduce/ToMaxTest.php
@@ -18,7 +18,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @param        callable|null $comparator
      * @param        int|float $expected
      */
-    public function testArray(array $data, ?callable $comparator, $expected)
+    public function testArray(array $data, ?callable $comparator, $expected): void
     {
         // When
         $result = Reduce::toMax($data, $comparator);
@@ -475,7 +475,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testGenerators(\Generator $data, ?callable $comparator, $expected)
+    public function testGenerators(\Generator $data, ?callable $comparator, $expected): void
     {
         // When
         $result = Reduce::toMax($data, $comparator);
@@ -936,7 +936,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testIterators(\Iterator $data, ?callable $comparator, $expected)
+    public function testIterators(\Iterator $data, ?callable $comparator, $expected): void
     {
         // When
         $result = Reduce::toMax($data, $comparator);
@@ -1397,7 +1397,7 @@ class ToMaxTest extends \PHPUnit\Framework\TestCase
      * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testTraversables(\Traversable $data, ?callable $comparator, $expected)
+    public function testTraversables(\Traversable $data, ?callable $comparator, $expected): void
     {
         // When
         $result = Reduce::toMax($data, $comparator);

--- a/tests/Reduce/ToMinMaxTest.php
+++ b/tests/Reduce/ToMinMaxTest.php
@@ -17,13 +17,13 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMinMax array
      * @dataProvider dataProviderForArray
      * @param        array $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        array $expected
      */
-    public function testArray(array $data, ?callable $comparator, array $expected)
+    public function testArray(array $data, ?callable $compareBy, array $expected)
     {
         // When
-        $result = Reduce::toMinMax($data, $comparator);
+        $result = Reduce::toMinMax($data, $compareBy);
 
         // Then
         $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
@@ -239,13 +239,13 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMinMax generators
      * @dataProvider dataProviderForGenerators
      * @param        \Generator $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        array $expected
      */
-    public function testGenerators(\Generator $data, ?callable $comparator, array $expected)
+    public function testGenerators(\Generator $data, ?callable $compareBy, array $expected)
     {
         // When
-        $result = Reduce::toMinMax($data, $comparator);
+        $result = Reduce::toMinMax($data, $compareBy);
 
         // Then
         $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
@@ -465,13 +465,13 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMinMax iterators
      * @dataProvider dataProviderForIterators
      * @param        \Generator $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        array $expected
      */
-    public function testIterators(\Iterator $data, ?callable $comparator, array $expected)
+    public function testIterators(\Iterator $data, ?callable $compareBy, array $expected)
     {
         // When
-        $result = Reduce::toMinMax($data, $comparator);
+        $result = Reduce::toMinMax($data, $compareBy);
 
         // Then
         $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
@@ -691,13 +691,13 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMinMax traversables
      * @dataProvider dataProviderForTraversables
      * @param        \Traversable $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        array $expected
      */
-    public function testTraversables(\Traversable $data, ?callable $comparator, array $expected)
+    public function testTraversables(\Traversable $data, ?callable $compareBy, array $expected)
     {
         // When
-        $result = Reduce::toMinMax($data, $comparator);
+        $result = Reduce::toMinMax($data, $compareBy);
 
         // Then
         $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
@@ -909,6 +909,60 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
                 fn ($item) => -$item[1],
                 [[1, 2, 3], [2, 0, 3]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForUsingClassMethodToCompare
+     * @param iterable $data
+     * @param callable|null $compareBy
+     * @param $expected
+     * @return void
+     */
+    public function testUsingClassMethodToCompare(iterable $data, ?callable $compareBy, $expected): void
+    {
+        // When
+        $result = Reduce::toMinMax($data, $compareBy);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForUsingClassMethodToCompare(): array
+    {
+        $helper = new class () {
+            public function direct(int $value): int
+            {
+                return $value;
+            }
+
+            public function reverse(int $value): int
+            {
+                return -$value;
+            }
+        };
+
+        return [
+            [
+                [1, 3, 2, 5, 0],
+                fn ($item) => $helper->direct($item),
+                [0, 5],
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                fn ($item) => $helper->reverse($item),
+                [5, 0],
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                [$helper, 'direct'],
+                [0, 5],
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                [$helper, 'reverse'],
+                [5, 0],
             ],
         ];
     }

--- a/tests/Reduce/ToMinMaxTest.php
+++ b/tests/Reduce/ToMinMaxTest.php
@@ -17,12 +17,13 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMinMax array
      * @dataProvider dataProviderForArray
      * @param        array $data
+     * @param        callable|null $comparator
      * @param        array $expected
      */
-    public function testArray(array $data, array $expected)
+    public function testArray(array $data, ?callable $comparator, array $expected)
     {
         // When
-        $result = Reduce::toMinMax($data);
+        $result = Reduce::toMinMax($data, $comparator);
 
         // Then
         $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
@@ -33,51 +34,208 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 [],
+                null,
+                [null, null],
+            ],
+            [
+                [],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null, null],
+            ],
+            [
+                [],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [null, null],
             ],
             [
                 [0],
+                null,
+                [0, 0],
+            ],
+            [
+                [0],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [0, 0],
+            ],
+            [
+                [0],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [0, 0],
             ],
             [
                 [1],
+                null,
+                [1, 1],
+            ],
+            [
+                [1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1],
+            ],
+            [
+                [1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [1, 1],
             ],
             [
                 [-1],
+                null,
+                [-1, -1],
+            ],
+            [
+                [-1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-1, -1],
+            ],
+            [
+                [-1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [-1, -1],
             ],
             [
                 [-1, -3, -5],
+                null,
                 [-5, -1],
             ],
             [
+                [-1, -3, -5],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-5, -1],
+            ],
+            [
+                [-1, -3, -5],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [-1, -5],
+            ],
+            [
                 [3, 1, 2, -3, -1, -2],
+                null,
                 [-3, 3],
             ],
             [
+                [3, 1, 2, -3, -1, -2],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3, 3],
+            ],
+            [
+                [3, 1, 2, -3, -1, -2],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, -3],
+            ],
+            [
                 [2.2, 3.3, 1.1],
+                null,
+                [1.1, 3.3],
+            ],
+            [
+                [2.2, 3.3, 1.1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1.1, 3.3],
+            ],
+            [
+                [2.2, 3.3, 1.1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3.3, 1.1],
+            ],
+            [
+                [2, 3.3, 1.1],
+                null,
                 [1.1, 3.3],
             ],
             [
                 [2, 3.3, 1.1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
                 [1.1, 3.3],
             ],
             [
+                [2, 3.3, 1.1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3.3, 1.1],
+            ],
+            [
                 [2.2, -3.3, -1.1, 2.2, 5.5],
+                null,
+                [-3.3, 5.5],
+            ],
+            [
+                [2.2, -3.3, -1.1, 2.2, 5.5],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3.3, 5.5],
+            ],
+            [
+                [2.2, -3.3, -1.1, 2.2, 5.5],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5.5, -3.3],
+            ],
+            [
+                ['2.2', '-3.3', '-1.1', '2.2', '5.5'],
+                null,
                 [-3.3, 5.5],
             ],
             [
                 ['2.2', '-3.3', '-1.1', '2.2', '5.5'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
                 [-3.3, 5.5],
             ],
             [
+                ['2.2', '-3.3', '-1.1', '2.2', '5.5'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5.5, -3.3],
+            ],
+            [
                 ['3', '4', '1'],
+                null,
                 [1, 4],
             ],
             [
+                ['3', '4', '1'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 4],
+            ],
+            [
+                ['3', '4', '1'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [4, 1],
+            ],
+            [
                 [2, -3.3, '-1.1', 2.2, '5'],
+                null,
                 [-3.3, 5],
+            ],
+            [
+                [2, -3.3, '-1.1', 2.2, '5'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3.3, 5],
+            ],
+            [
+                [2, -3.3, '-1.1', 2.2, '5'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5, -3.3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                null,
+                [[1, 2, 3], [2, 1, 3]],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[1, 2, 3], [2, 1, 3]],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[2, 1, 3], [1, 2, 3]],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [[2, 0, 3], [1, 2, 3]],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [[1, 2, 3], [2, 0, 3]],
             ],
         ];
     }
@@ -86,12 +244,13 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMinMax generators
      * @dataProvider dataProviderForGenerators
      * @param        \Generator $data
+     * @param        callable|null $comparator
      * @param        array $expected
      */
-    public function testGenerators(\Generator $data, array $expected)
+    public function testGenerators(\Generator $data, ?callable $comparator, array $expected)
     {
         // When
-        $result = Reduce::toMinMax($data);
+        $result = Reduce::toMinMax($data, $comparator);
 
         // Then
         $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
@@ -106,51 +265,208 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $gen([]),
+                null,
+                [null, null],
+            ],
+            [
+                $gen([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null, null],
+            ],
+            [
+                $gen([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [null, null],
             ],
             [
                 $gen([0]),
+                null,
+                [0, 0],
+            ],
+            [
+                $gen([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [0, 0],
+            ],
+            [
+                $gen([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [0, 0],
             ],
             [
                 $gen([1]),
+                null,
+                [1, 1],
+            ],
+            [
+                $gen([1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1],
+            ],
+            [
+                $gen([1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [1, 1],
             ],
             [
                 $gen([-1]),
+                null,
+                [-1, -1],
+            ],
+            [
+                $gen([-1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-1, -1],
+            ],
+            [
+                $gen([-1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [-1, -1],
             ],
             [
                 $gen([-1, -3, -5]),
+                null,
                 [-5, -1],
             ],
             [
+                $gen([-1, -3, -5]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-5, -1],
+            ],
+            [
+                $gen([-1, -3, -5]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [-1, -5],
+            ],
+            [
                 $gen([3, 1, 2, -3, -1, -2]),
+                null,
                 [-3, 3],
             ],
             [
+                $gen([3, 1, 2, -3, -1, -2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3, 3],
+            ],
+            [
+                $gen([3, 1, 2, -3, -1, -2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, -3],
+            ],
+            [
                 $gen([2.2, 3.3, 1.1]),
+                null,
+                [1.1, 3.3],
+            ],
+            [
+                $gen([2.2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1.1, 3.3],
+            ],
+            [
+                $gen([2.2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3.3, 1.1],
+            ],
+            [
+                $gen([2, 3.3, 1.1]),
+                null,
                 [1.1, 3.3],
             ],
             [
                 $gen([2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
                 [1.1, 3.3],
             ],
             [
+                $gen([2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3.3, 1.1],
+            ],
+            [
                 $gen([2.2, -3.3, -1.1, 2.2, 5.5]),
+                null,
+                [-3.3, 5.5],
+            ],
+            [
+                $gen([2.2, -3.3, -1.1, 2.2, 5.5]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3.3, 5.5],
+            ],
+            [
+                $gen([2.2, -3.3, -1.1, 2.2, 5.5]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5.5, -3.3],
+            ],
+            [
+                $gen(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                null,
                 [-3.3, 5.5],
             ],
             [
                 $gen(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
                 [-3.3, 5.5],
             ],
             [
+                $gen(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5.5, -3.3],
+            ],
+            [
                 $gen(['3', '4', '1']),
+                null,
                 [1, 4],
             ],
             [
+                $gen(['3', '4', '1']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 4],
+            ],
+            [
+                $gen(['3', '4', '1']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [4, 1],
+            ],
+            [
                 $gen([2, -3.3, '-1.1', 2.2, '5']),
+                null,
                 [-3.3, 5],
+            ],
+            [
+                $gen([2, -3.3, '-1.1', 2.2, '5']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3.3, 5],
+            ],
+            [
+                $gen([2, -3.3, '-1.1', 2.2, '5']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5, -3.3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [[1, 2, 3], [2, 1, 3]],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[1, 2, 3], [2, 1, 3]],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[2, 1, 3], [1, 2, 3]],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [[2, 0, 3], [1, 2, 3]],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [[1, 2, 3], [2, 0, 3]],
             ],
         ];
     }
@@ -159,12 +475,13 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMinMax iterators
      * @dataProvider dataProviderForIterators
      * @param        \Generator $data
+     * @param        callable|null $comparator
      * @param        array $expected
      */
-    public function testIterators(\Iterator $data, array $expected)
+    public function testIterators(\Iterator $data, ?callable $comparator, array $expected)
     {
         // When
-        $result = Reduce::toMinMax($data);
+        $result = Reduce::toMinMax($data, $comparator);
 
         // Then
         $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
@@ -172,58 +489,215 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
 
     public function dataProviderForIterators(): array
     {
-        $iter = static function (array $data) {
+        $trav = static function (array $data) {
             return new ArrayIteratorFixture($data);
         };
 
         return [
             [
-                $iter([]),
+                $trav([]),
+                null,
                 [null, null],
             ],
             [
-                $iter([0]),
+                $trav([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null, null],
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null, null],
+            ],
+            [
+                $trav([0]),
+                null,
                 [0, 0],
             ],
             [
-                $iter([1]),
+                $trav([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [0, 0],
+            ],
+            [
+                $trav([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [0, 0],
+            ],
+            [
+                $trav([1]),
+                null,
                 [1, 1],
             ],
             [
-                $iter([-1]),
+                $trav([1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1],
+            ],
+            [
+                $trav([1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 1],
+            ],
+            [
+                $trav([-1]),
+                null,
                 [-1, -1],
             ],
             [
-                $iter([-1, -3, -5]),
+                $trav([-1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-1, -1],
+            ],
+            [
+                $trav([-1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [-1, -1],
+            ],
+            [
+                $trav([-1, -3, -5]),
+                null,
                 [-5, -1],
             ],
             [
-                $iter([3, 1, 2, -3, -1, -2]),
+                $trav([-1, -3, -5]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-5, -1],
+            ],
+            [
+                $trav([-1, -3, -5]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [-1, -5],
+            ],
+            [
+                $trav([3, 1, 2, -3, -1, -2]),
+                null,
                 [-3, 3],
             ],
             [
-                $iter([2.2, 3.3, 1.1]),
+                $trav([3, 1, 2, -3, -1, -2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3, 3],
+            ],
+            [
+                $trav([3, 1, 2, -3, -1, -2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, -3],
+            ],
+            [
+                $trav([2.2, 3.3, 1.1]),
+                null,
                 [1.1, 3.3],
             ],
             [
-                $iter([2, 3.3, 1.1]),
+                $trav([2.2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
                 [1.1, 3.3],
             ],
             [
-                $iter([2.2, -3.3, -1.1, 2.2, 5.5]),
+                $trav([2.2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3.3, 1.1],
+            ],
+            [
+                $trav([2, 3.3, 1.1]),
+                null,
+                [1.1, 3.3],
+            ],
+            [
+                $trav([2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1.1, 3.3],
+            ],
+            [
+                $trav([2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3.3, 1.1],
+            ],
+            [
+                $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
+                null,
                 [-3.3, 5.5],
             ],
             [
-                $iter(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
                 [-3.3, 5.5],
             ],
             [
-                $iter(['3', '4', '1']),
+                $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5.5, -3.3],
+            ],
+            [
+                $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                null,
+                [-3.3, 5.5],
+            ],
+            [
+                $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3.3, 5.5],
+            ],
+            [
+                $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5.5, -3.3],
+            ],
+            [
+                $trav(['3', '4', '1']),
+                null,
                 [1, 4],
             ],
             [
-                $iter([2, -3.3, '-1.1', 2.2, '5']),
+                $trav(['3', '4', '1']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 4],
+            ],
+            [
+                $trav(['3', '4', '1']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [4, 1],
+            ],
+            [
+                $trav([2, -3.3, '-1.1', 2.2, '5']),
+                null,
                 [-3.3, 5],
+            ],
+            [
+                $trav([2, -3.3, '-1.1', 2.2, '5']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3.3, 5],
+            ],
+            [
+                $trav([2, -3.3, '-1.1', 2.2, '5']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5, -3.3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [[1, 2, 3], [2, 1, 3]],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[1, 2, 3], [2, 1, 3]],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[2, 1, 3], [1, 2, 3]],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [[2, 0, 3], [1, 2, 3]],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [[1, 2, 3], [2, 0, 3]],
             ],
         ];
     }
@@ -232,12 +706,13 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
      * @test         toMinMax traversables
      * @dataProvider dataProviderForTraversables
      * @param        \Traversable $data
+     * @param        callable|null $comparator
      * @param        array $expected
      */
-    public function testTraversables(\Traversable $data, array $expected)
+    public function testTraversables(\Traversable $data, ?callable $comparator, array $expected)
     {
         // When
-        $result = Reduce::toMinMax($data);
+        $result = Reduce::toMinMax($data, $comparator);
 
         // Then
         $this->assertEqualsWithDelta($expected, $result, self::ROUND_PRECISION);
@@ -252,51 +727,208 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $trav([]),
+                null,
+                [null, null],
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null, null],
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [null, null],
             ],
             [
                 $trav([0]),
+                null,
+                [0, 0],
+            ],
+            [
+                $trav([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [0, 0],
+            ],
+            [
+                $trav([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [0, 0],
             ],
             [
                 $trav([1]),
+                null,
+                [1, 1],
+            ],
+            [
+                $trav([1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1],
+            ],
+            [
+                $trav([1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [1, 1],
             ],
             [
                 $trav([-1]),
+                null,
+                [-1, -1],
+            ],
+            [
+                $trav([-1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-1, -1],
+            ],
+            [
+                $trav([-1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
                 [-1, -1],
             ],
             [
                 $trav([-1, -3, -5]),
+                null,
                 [-5, -1],
             ],
             [
+                $trav([-1, -3, -5]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-5, -1],
+            ],
+            [
+                $trav([-1, -3, -5]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [-1, -5],
+            ],
+            [
                 $trav([3, 1, 2, -3, -1, -2]),
+                null,
                 [-3, 3],
             ],
             [
+                $trav([3, 1, 2, -3, -1, -2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3, 3],
+            ],
+            [
+                $trav([3, 1, 2, -3, -1, -2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, -3],
+            ],
+            [
                 $trav([2.2, 3.3, 1.1]),
+                null,
+                [1.1, 3.3],
+            ],
+            [
+                $trav([2.2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1.1, 3.3],
+            ],
+            [
+                $trav([2.2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3.3, 1.1],
+            ],
+            [
+                $trav([2, 3.3, 1.1]),
+                null,
                 [1.1, 3.3],
             ],
             [
                 $trav([2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
                 [1.1, 3.3],
             ],
             [
+                $trav([2, 3.3, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3.3, 1.1],
+            ],
+            [
                 $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
+                null,
+                [-3.3, 5.5],
+            ],
+            [
+                $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3.3, 5.5],
+            ],
+            [
+                $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5.5, -3.3],
+            ],
+            [
+                $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                null,
                 [-3.3, 5.5],
             ],
             [
                 $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
                 [-3.3, 5.5],
             ],
             [
+                $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5.5, -3.3],
+            ],
+            [
                 $trav(['3', '4', '1']),
+                null,
                 [1, 4],
             ],
             [
+                $trav(['3', '4', '1']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 4],
+            ],
+            [
+                $trav(['3', '4', '1']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [4, 1],
+            ],
+            [
                 $trav([2, -3.3, '-1.1', 2.2, '5']),
+                null,
                 [-3.3, 5],
+            ],
+            [
+                $trav([2, -3.3, '-1.1', 2.2, '5']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-3.3, 5],
+            ],
+            [
+                $trav([2, -3.3, '-1.1', 2.2, '5']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [5, -3.3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [[1, 2, 3], [2, 1, 3]],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[1, 2, 3], [2, 1, 3]],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[2, 1, 3], [1, 2, 3]],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [[2, 0, 3], [1, 2, 3]],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [[1, 2, 3], [2, 0, 3]],
             ],
         ];
     }

--- a/tests/Reduce/ToMinMaxTest.php
+++ b/tests/Reduce/ToMinMaxTest.php
@@ -39,12 +39,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null, null],
             ],
             [
                 [],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [null, null],
             ],
             [
@@ -54,12 +54,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [0],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [0, 0],
             ],
             [
                 [0],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [0, 0],
             ],
             [
@@ -69,12 +69,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 1],
             ],
             [
                 [1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [1, 1],
             ],
             [
@@ -84,12 +84,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [-1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-1, -1],
             ],
             [
                 [-1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [-1, -1],
             ],
             [
@@ -99,12 +99,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [-1, -3, -5],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-5, -1],
             ],
             [
                 [-1, -3, -5],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [-1, -5],
             ],
             [
@@ -114,12 +114,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [3, 1, 2, -3, -1, -2],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3, 3],
             ],
             [
                 [3, 1, 2, -3, -1, -2],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3, -3],
             ],
             [
@@ -129,12 +129,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2.2, 3.3, 1.1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1.1, 3.3],
             ],
             [
                 [2.2, 3.3, 1.1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3.3, 1.1],
             ],
             [
@@ -144,12 +144,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2, 3.3, 1.1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1.1, 3.3],
             ],
             [
                 [2, 3.3, 1.1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3.3, 1.1],
             ],
             [
@@ -159,12 +159,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2.2, -3.3, -1.1, 2.2, 5.5],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5.5],
             ],
             [
                 [2.2, -3.3, -1.1, 2.2, 5.5],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5.5, -3.3],
             ],
             [
@@ -174,12 +174,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['2.2', '-3.3', '-1.1', '2.2', '5.5'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5.5],
             ],
             [
                 ['2.2', '-3.3', '-1.1', '2.2', '5.5'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5.5, -3.3],
             ],
             [
@@ -189,12 +189,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['3', '4', '1'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 4],
             ],
             [
                 ['3', '4', '1'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [4, 1],
             ],
             [
@@ -204,12 +204,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2, -3.3, '-1.1', 2.2, '5'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5],
             ],
             [
                 [2, -3.3, '-1.1', 2.2, '5'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5, -3.3],
             ],
             [
@@ -219,22 +219,17 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [[1, 2, 3], [2, 1, 3]],
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [[2, 1, 3], [1, 2, 3]],
-            ],
-            [
-                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                fn ($item) => $item[1],
                 [[2, 0, 3], [1, 2, 3]],
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [[1, 2, 3], [2, 0, 3]],
             ],
         ];
@@ -270,12 +265,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null, null],
             ],
             [
                 $gen([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [null, null],
             ],
             [
@@ -285,12 +280,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [0, 0],
             ],
             [
                 $gen([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [0, 0],
             ],
             [
@@ -300,12 +295,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 1],
             ],
             [
                 $gen([1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [1, 1],
             ],
             [
@@ -315,12 +310,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([-1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-1, -1],
             ],
             [
                 $gen([-1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [-1, -1],
             ],
             [
@@ -330,12 +325,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([-1, -3, -5]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-5, -1],
             ],
             [
                 $gen([-1, -3, -5]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [-1, -5],
             ],
             [
@@ -345,12 +340,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([3, 1, 2, -3, -1, -2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3, 3],
             ],
             [
                 $gen([3, 1, 2, -3, -1, -2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3, -3],
             ],
             [
@@ -360,12 +355,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2.2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1.1, 3.3],
             ],
             [
                 $gen([2.2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3.3, 1.1],
             ],
             [
@@ -375,12 +370,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1.1, 3.3],
             ],
             [
                 $gen([2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3.3, 1.1],
             ],
             [
@@ -390,12 +385,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2.2, -3.3, -1.1, 2.2, 5.5]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5.5],
             ],
             [
                 $gen([2.2, -3.3, -1.1, 2.2, 5.5]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5.5, -3.3],
             ],
             [
@@ -405,12 +400,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5.5],
             ],
             [
                 $gen(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5.5, -3.3],
             ],
             [
@@ -420,12 +415,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['3', '4', '1']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 4],
             ],
             [
                 $gen(['3', '4', '1']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [4, 1],
             ],
             [
@@ -435,12 +430,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2, -3.3, '-1.1', 2.2, '5']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5],
             ],
             [
                 $gen([2, -3.3, '-1.1', 2.2, '5']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5, -3.3],
             ],
             [
@@ -450,22 +445,17 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [[1, 2, 3], [2, 1, 3]],
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [[2, 1, 3], [1, 2, 3]],
-            ],
-            [
-                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                fn ($item) => $item[1],
                 [[2, 0, 3], [1, 2, 3]],
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [[1, 2, 3], [2, 0, 3]],
             ],
         ];
@@ -501,12 +491,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null, null],
             ],
             [
                 $trav([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [null, null],
             ],
             [
@@ -516,12 +506,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [0, 0],
             ],
             [
                 $trav([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [0, 0],
             ],
             [
@@ -531,12 +521,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 1],
             ],
             [
                 $trav([1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [1, 1],
             ],
             [
@@ -546,12 +536,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([-1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-1, -1],
             ],
             [
                 $trav([-1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [-1, -1],
             ],
             [
@@ -561,12 +551,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([-1, -3, -5]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-5, -1],
             ],
             [
                 $trav([-1, -3, -5]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [-1, -5],
             ],
             [
@@ -576,12 +566,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([3, 1, 2, -3, -1, -2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3, 3],
             ],
             [
                 $trav([3, 1, 2, -3, -1, -2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3, -3],
             ],
             [
@@ -591,12 +581,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2.2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1.1, 3.3],
             ],
             [
                 $trav([2.2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3.3, 1.1],
             ],
             [
@@ -606,12 +596,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1.1, 3.3],
             ],
             [
                 $trav([2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3.3, 1.1],
             ],
             [
@@ -621,12 +611,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5.5],
             ],
             [
                 $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5.5, -3.3],
             ],
             [
@@ -636,12 +626,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5.5],
             ],
             [
                 $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5.5, -3.3],
             ],
             [
@@ -651,12 +641,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['3', '4', '1']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 4],
             ],
             [
                 $trav(['3', '4', '1']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [4, 1],
             ],
             [
@@ -666,12 +656,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2, -3.3, '-1.1', 2.2, '5']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5],
             ],
             [
                 $trav([2, -3.3, '-1.1', 2.2, '5']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5, -3.3],
             ],
             [
@@ -681,22 +671,17 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [[1, 2, 3], [2, 1, 3]],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [[2, 1, 3], [1, 2, 3]],
-            ],
-            [
-                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                fn ($item) => $item[1],
                 [[2, 0, 3], [1, 2, 3]],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [[1, 2, 3], [2, 0, 3]],
             ],
         ];
@@ -732,12 +717,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [null, null],
             ],
             [
                 $trav([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [null, null],
             ],
             [
@@ -747,12 +732,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [0, 0],
             ],
             [
                 $trav([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [0, 0],
             ],
             [
@@ -762,12 +747,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 1],
             ],
             [
                 $trav([1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [1, 1],
             ],
             [
@@ -777,12 +762,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([-1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-1, -1],
             ],
             [
                 $trav([-1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [-1, -1],
             ],
             [
@@ -792,12 +777,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([-1, -3, -5]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-5, -1],
             ],
             [
                 $trav([-1, -3, -5]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [-1, -5],
             ],
             [
@@ -807,12 +792,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([3, 1, 2, -3, -1, -2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3, 3],
             ],
             [
                 $trav([3, 1, 2, -3, -1, -2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3, -3],
             ],
             [
@@ -822,12 +807,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2.2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1.1, 3.3],
             ],
             [
                 $trav([2.2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3.3, 1.1],
             ],
             [
@@ -837,12 +822,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1.1, 3.3],
             ],
             [
                 $trav([2, 3.3, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [3.3, 1.1],
             ],
             [
@@ -852,12 +837,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5.5],
             ],
             [
                 $trav([2.2, -3.3, -1.1, 2.2, 5.5]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5.5, -3.3],
             ],
             [
@@ -867,12 +852,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5.5],
             ],
             [
                 $trav(['2.2', '-3.3', '-1.1', '2.2', '5.5']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5.5, -3.3],
             ],
             [
@@ -882,12 +867,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['3', '4', '1']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 4],
             ],
             [
                 $trav(['3', '4', '1']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [4, 1],
             ],
             [
@@ -897,12 +882,12 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2, -3.3, '-1.1', 2.2, '5']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [-3.3, 5],
             ],
             [
                 $trav([2, -3.3, '-1.1', 2.2, '5']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 [5, -3.3],
             ],
             [
@@ -912,22 +897,17 @@ class ToMinMaxTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [[1, 2, 3], [2, 1, 3]],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [[2, 1, 3], [1, 2, 3]],
-            ],
-            [
-                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                fn ($item) => $item[1],
                 [[2, 0, 3], [1, 2, 3]],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [[1, 2, 3], [2, 0, 3]],
             ],
         ];

--- a/tests/Reduce/ToMinTest.php
+++ b/tests/Reduce/ToMinTest.php
@@ -15,12 +15,13 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @test         toMin array
      * @dataProvider dataProviderForArray
      * @param        array $data
+     * @param        callable|null $comparator
      * @param        int|float $expected
      */
-    public function testArray(array $data, $expected)
+    public function testArray(array $data, ?callable $comparator, $expected)
     {
         // When
-        $result = Reduce::toMin($data);
+        $result = Reduce::toMin($data, $comparator);
 
         // Then
         $this->assertSame($expected, $result);
@@ -31,131 +32,508 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 [],
-                null
+                null,
+                null,
+            ],
+            [
+                [],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                null,
+            ],
+            [
+                [],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                null,
             ],
             [
                 [0],
-                0
+                null,
+                0,
+            ],
+            [
+                [0],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                0,
+            ],
+            [
+                [0],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                0,
             ],
             [
                 [INF],
-                INF
+                null,
+                INF,
+            ],
+            [
+                [INF],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                [INF],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 [-INF],
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                [-INF],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                [-INF],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 [INF, -INF],
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                [INF, -INF],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                [INF, -INF],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 [INF, -INF, 10, -1],
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                [INF, -INF, 10, -1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                [INF, -INF, 10, -1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 [1, 2, 3],
-                1
+                null,
+                1,
+            ],
+            [
+                [1, 2, 3],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                [1, 2, 3],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
             ],
             [
                 [3, 2, 1],
-                1
+                null,
+                1,
             ],
             [
                 [3, 2, 1],
-                1
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                [3, 2, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
+            ],
+            [
+                [3, 2, 1],
+                null,
+                1,
+            ],
+            [
+                [3, 2, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                [3, 2, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
             ],
             [
                 [2.1, 1],
-                1
+                null,
+                1,
+            ],
+            [
+                [2.1, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                [2.1, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.1,
             ],
             [
                 [2, 1.1],
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                [2, 1.1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                [2, 1.1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2,
             ],
             [
                 [2.2, 1.1],
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                [2.2, 1.1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                [2.2, 1.1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.2,
             ],
             [
                 [1.1, 2.2],
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                [1.1, 2.2],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                [1.1, 2.2],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.2,
             ],
             [
                 ['a', 'b', 'c'],
-                'a'
+                null,
+                'a',
+            ],
+            [
+                ['a', 'b', 'c'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                ['a', 'b', 'c'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 ['b', 'c', 'a'],
-                'a'
+                null,
+                'a',
+            ],
+            [
+                ['b', 'c', 'a'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                ['b', 'c', 'a'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 ['c', 'b', 'a'],
-                'a'
+                null,
+                'a',
+            ],
+            [
+                ['c', 'b', 'a'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                ['c', 'b', 'a'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 ['ab', 'ba', 'b'],
-                'ab'
+                null,
+                'ab',
+            ],
+            [
+                ['ab', 'ba', 'b'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ab',
+            ],
+            [
+                ['ab', 'ba', 'b'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ba',
             ],
             [
                 ['ba', 'b', 'ab'],
-                'ab'
+                null,
+                'ab',
+            ],
+            [
+                ['ba', 'b', 'ab'],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ab',
+            ],
+            [
+                ['ba', 'b', 'ab'],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ba',
             ],
             [
                 [[]],
-                []
+                null,
+                [],
+            ],
+            [
+                [[]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [[]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 [[2]],
-                [2]
+                null,
+                [2],
+            ],
+            [
+                [[2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                [[2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 [[], []],
-                []
+                null,
+                [],
+            ],
+            [
+                [[], []],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [[], []],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 [[], [2]],
-                []
+                null,
+                [],
+            ],
+            [
+                [[], [2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [[], [2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 [[2], []],
-                []
+                null,
+                [],
+            ],
+            [
+                [[2], []],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [[2], []],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 [[], [null]],
-                []
+                null,
+                [],
+            ],
+            [
+                [[], [null]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [[], [null]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 [[null], []],
-                []
+                null,
+                [],
+            ],
+            [
+                [[null], []],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [[null], []],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 [[null], [null]],
-                [null]
+                null,
+                [null],
+            ],
+            [
+                [[null], [null]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                [[null], [null]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 [[1, 2], [2]],
-                [2]
+                null,
+                [2],
+            ],
+            [
+                [[1, 2], [2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                [[1, 2], [2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 [[3, 2], [2]],
-                [2]
+                null,
+                [2],
+            ],
+            [
+                [[3, 2], [2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                [[3, 2], [2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, 2],
             ],
             [
                 [[1, 2], [2, 1]],
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                [[1, 2], [2, 1]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                [[1, 2], [2, 1]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
             ],
             [
                 [[2, 1], [1, 2]],
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                [[2, 1], [1, 2]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                [[2, 1], [1, 2]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
             ],
             [
                 [['a'], ['b']],
-                ['a']
+                null,
+                ['a'],
+            ],
+            [
+                [['a'], ['b']],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['a'],
+            ],
+            [
+                [['a'], ['b']],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['b'],
             ],
             [
                 [['a', 'a'], ['b']],
-                ['b']
+                null,
+                ['b'],
+            ],
+            [
+                [['a', 'a'], ['b']],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['b'],
+            ],
+            [
+                [['a', 'a'], ['b']],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['a', 'a'],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                null,
+                [1, 2, 3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2, 3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1, 3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [2, 0, 3],
+            ],
+            [
+                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [1, 2, 3],
             ],
         ];
     }
@@ -164,12 +542,13 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @test         toMin generators
      * @dataProvider dataProviderForGenerators
      * @param        \Generator $data
+     * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testGenerators(\Generator $data, $expected)
+    public function testGenerators(\Generator $data, ?callable $comparator, $expected)
     {
         // When
-        $result = Reduce::toMin($data);
+        $result = Reduce::toMin($data, $comparator);
 
         // Then
         $this->assertSame($expected, $result);
@@ -184,131 +563,508 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $gen([]),
-                null
+                null,
+                null,
+            ],
+            [
+                $gen([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                null,
+            ],
+            [
+                $gen([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                null,
             ],
             [
                 $gen([0]),
-                0
+                null,
+                0,
+            ],
+            [
+                $gen([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                0,
+            ],
+            [
+                $gen([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                0,
             ],
             [
                 $gen([INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $gen([INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $gen([INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $gen([-INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $gen([-INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $gen([-INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $gen([INF, -INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $gen([INF, -INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $gen([INF, -INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $gen([INF, -INF, 10, -1]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $gen([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $gen([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $gen([1, 2, 3]),
-                1
+                null,
+                1,
+            ],
+            [
+                $gen([1, 2, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $gen([1, 2, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
             ],
             [
                 $gen([3, 2, 1]),
-                1
+                null,
+                1,
             ],
             [
-                $gen([2, 1, 3]),
-                1
+                $gen([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $gen([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
+            ],
+            [
+                $gen([3, 2, 1]),
+                null,
+                1,
+            ],
+            [
+                $gen([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $gen([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
             ],
             [
                 $gen([2.1, 1]),
-                1
+                null,
+                1,
+            ],
+            [
+                $gen([2.1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $gen([2.1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.1,
             ],
             [
                 $gen([2, 1.1]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $gen([2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $gen([2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2,
             ],
             [
                 $gen([2.2, 1.1]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $gen([2.2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $gen([2.2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.2,
             ],
             [
                 $gen([1.1, 2.2]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $gen([1.1, 2.2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $gen([1.1, 2.2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.2,
             ],
             [
                 $gen(['a', 'b', 'c']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $gen(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $gen(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $gen(['b', 'c', 'a']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $gen(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $gen(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $gen(['c', 'b', 'a']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $gen(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $gen(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $gen(['ab', 'ba', 'b']),
-                'ab'
+                null,
+                'ab',
+            ],
+            [
+                $gen(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ab',
+            ],
+            [
+                $gen(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ba',
             ],
             [
                 $gen(['ba', 'b', 'ab']),
-                'ab'
+                null,
+                'ab',
+            ],
+            [
+                $gen(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ab',
+            ],
+            [
+                $gen(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ba',
             ],
             [
                 $gen([[]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $gen([[]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $gen([[]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $gen([[2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $gen([[2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $gen([[2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $gen([[], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $gen([[], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $gen([[], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $gen([[], [2]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $gen([[], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $gen([[], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $gen([[2], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $gen([[2], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $gen([[2], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $gen([[], [null]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $gen([[], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $gen([[], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $gen([[null], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $gen([[null], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $gen([[null], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $gen([[null], [null]]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $gen([[null], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $gen([[null], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $gen([[1, 2], [2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $gen([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $gen([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 $gen([[3, 2], [2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $gen([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $gen([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, 2],
             ],
             [
                 $gen([[1, 2], [2, 1]]),
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                $gen([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $gen([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
             ],
             [
                 $gen([[2, 1], [1, 2]]),
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                $gen([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $gen([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
             ],
             [
                 $gen([['a'], ['b']]),
-                ['a']
+                null,
+                ['a'],
+            ],
+            [
+                $gen([['a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['a'],
+            ],
+            [
+                $gen([['a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['b'],
             ],
             [
                 $gen([['a', 'a'], ['b']]),
-                ['b']
+                null,
+                ['b'],
+            ],
+            [
+                $gen([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['b'],
+            ],
+            [
+                $gen([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['a', 'a'],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [1, 2, 3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2, 3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1, 3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [2, 0, 3],
+            ],
+            [
+                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [1, 2, 3],
             ],
         ];
     }
@@ -317,12 +1073,13 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @test         toMin iterators
      * @dataProvider dataProviderForIterators
      * @param        \Generator $data
+     * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testIterators(\Iterator $data, $expected)
+    public function testIterators(\Iterator $data, ?callable $comparator, $expected)
     {
         // When
-        $result = Reduce::toMin($data);
+        $result = Reduce::toMin($data, $comparator);
 
         // Then
         $this->assertSame($expected, $result);
@@ -330,138 +1087,515 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
 
     public function dataProviderForIterators(): array
     {
+
         $iter = static function (array $data) {
             return new ArrayIteratorFixture($data);
         };
-
         return [
             [
                 $iter([]),
-                null
+                null,
+                null,
+            ],
+            [
+                $iter([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                null,
+            ],
+            [
+                $iter([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                null,
             ],
             [
                 $iter([0]),
-                0
+                null,
+                0,
+            ],
+            [
+                $iter([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                0,
+            ],
+            [
+                $iter([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                0,
             ],
             [
                 $iter([INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $iter([INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $iter([INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $iter([-INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $iter([-INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $iter([-INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $iter([INF, -INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $iter([INF, -INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $iter([INF, -INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $iter([INF, -INF, 10, -1]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $iter([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $iter([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $iter([1, 2, 3]),
-                1
+                null,
+                1,
+            ],
+            [
+                $iter([1, 2, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $iter([1, 2, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
             ],
             [
                 $iter([3, 2, 1]),
-                1
+                null,
+                1,
             ],
             [
-                $iter([2, 1, 3]),
-                1
+                $iter([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $iter([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
+            ],
+            [
+                $iter([3, 2, 1]),
+                null,
+                1,
+            ],
+            [
+                $iter([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $iter([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
             ],
             [
                 $iter([2.1, 1]),
-                1
+                null,
+                1,
+            ],
+            [
+                $iter([2.1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $iter([2.1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.1,
             ],
             [
                 $iter([2, 1.1]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $iter([2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $iter([2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2,
             ],
             [
                 $iter([2.2, 1.1]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $iter([2.2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $iter([2.2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.2,
             ],
             [
                 $iter([1.1, 2.2]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $iter([1.1, 2.2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $iter([1.1, 2.2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.2,
             ],
             [
                 $iter(['a', 'b', 'c']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $iter(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $iter(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $iter(['b', 'c', 'a']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $iter(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $iter(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $iter(['c', 'b', 'a']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $iter(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $iter(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $iter(['ab', 'ba', 'b']),
-                'ab'
+                null,
+                'ab',
+            ],
+            [
+                $iter(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ab',
+            ],
+            [
+                $iter(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ba',
             ],
             [
                 $iter(['ba', 'b', 'ab']),
-                'ab'
+                null,
+                'ab',
+            ],
+            [
+                $iter(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ab',
+            ],
+            [
+                $iter(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ba',
             ],
             [
                 $iter([[]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $iter([[]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([[]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $iter([[2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $iter([[2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $iter([[2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $iter([[], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $iter([[], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([[], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $iter([[], [2]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $iter([[], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([[], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $iter([[2], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $iter([[2], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([[2], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $iter([[], [null]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $iter([[], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([[], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $iter([[null], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $iter([[null], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([[null], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $iter([[null], [null]]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $iter([[null], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $iter([[null], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $iter([[1, 2], [2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $iter([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $iter([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 $iter([[3, 2], [2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $iter([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $iter([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, 2],
             ],
             [
                 $iter([[1, 2], [2, 1]]),
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                $iter([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $iter([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
             ],
             [
                 $iter([[2, 1], [1, 2]]),
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                $iter([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $iter([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
             ],
             [
                 $iter([['a'], ['b']]),
-                ['a']
+                null,
+                ['a'],
+            ],
+            [
+                $iter([['a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['a'],
+            ],
+            [
+                $iter([['a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['b'],
             ],
             [
                 $iter([['a', 'a'], ['b']]),
-                ['b']
+                null,
+                ['b'],
+            ],
+            [
+                $iter([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['b'],
+            ],
+            [
+                $iter([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['a', 'a'],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [1, 2, 3],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2, 3],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1, 3],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [2, 0, 3],
+            ],
+            [
+                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [1, 2, 3],
             ],
         ];
     }
@@ -470,12 +1604,13 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @test         toMin traversables
      * @dataProvider dataProviderForTraversables
      * @param        \Traversable $data
+     * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testTraversables(\Traversable $data, $expected)
+    public function testTraversables(\Traversable $data, ?callable $comparator, $expected)
     {
         // When
-        $result = Reduce::toMin($data);
+        $result = Reduce::toMin($data, $comparator);
 
         // Then
         $this->assertSame($expected, $result);
@@ -490,131 +1625,508 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 $trav([]),
-                null
+                null,
+                null,
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                null,
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                null,
             ],
             [
                 $trav([0]),
-                0
+                null,
+                0,
+            ],
+            [
+                $trav([0]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                0,
+            ],
+            [
+                $trav([0]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                0,
             ],
             [
                 $trav([INF]),
-                INF
+                null,
+                INF,
+            ],
+            [
+                $trav([INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                INF,
+            ],
+            [
+                $trav([INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $trav([-INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $trav([-INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $trav([-INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                -INF,
             ],
             [
                 $trav([INF, -INF]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $trav([INF, -INF]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $trav([INF, -INF]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $trav([INF, -INF, 10, -1]),
-                -INF
+                null,
+                -INF,
+            ],
+            [
+                $trav([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                -INF,
+            ],
+            [
+                $trav([INF, -INF, 10, -1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                INF,
             ],
             [
                 $trav([1, 2, 3]),
-                1
+                null,
+                1,
+            ],
+            [
+                $trav([1, 2, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $trav([1, 2, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
             ],
             [
                 $trav([3, 2, 1]),
-                1
+                null,
+                1,
             ],
             [
-                $trav([2, 1, 3]),
-                1
+                $trav([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $trav([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
+            ],
+            [
+                $trav([3, 2, 1]),
+                null,
+                1,
+            ],
+            [
+                $trav([3, 2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $trav([3, 2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                3,
             ],
             [
                 $trav([2.1, 1]),
-                1
+                null,
+                1,
+            ],
+            [
+                $trav([2.1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1,
+            ],
+            [
+                $trav([2.1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.1,
             ],
             [
                 $trav([2, 1.1]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $trav([2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $trav([2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2,
             ],
             [
                 $trav([2.2, 1.1]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $trav([2.2, 1.1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $trav([2.2, 1.1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.2,
             ],
             [
                 $trav([1.1, 2.2]),
-                1.1
+                null,
+                1.1,
+            ],
+            [
+                $trav([1.1, 2.2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                1.1,
+            ],
+            [
+                $trav([1.1, 2.2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                2.2,
             ],
             [
                 $trav(['a', 'b', 'c']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $trav(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $trav(['a', 'b', 'c']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $trav(['b', 'c', 'a']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $trav(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $trav(['b', 'c', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $trav(['c', 'b', 'a']),
-                'a'
+                null,
+                'a',
+            ],
+            [
+                $trav(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'a',
+            ],
+            [
+                $trav(['c', 'b', 'a']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'c',
             ],
             [
                 $trav(['ab', 'ba', 'b']),
-                'ab'
+                null,
+                'ab',
+            ],
+            [
+                $trav(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ab',
+            ],
+            [
+                $trav(['ab', 'ba', 'b']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ba',
             ],
             [
                 $trav(['ba', 'b', 'ab']),
-                'ab'
+                null,
+                'ab',
+            ],
+            [
+                $trav(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                'ab',
+            ],
+            [
+                $trav(['ba', 'b', 'ab']),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                'ba',
             ],
             [
                 $trav([[]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $trav([[]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([[]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $trav([[2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $trav([[2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $trav([[2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $trav([[], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $trav([[], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([[], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
             ],
             [
                 $trav([[], [2]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $trav([[], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([[], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $trav([[2], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $trav([[2], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([[2], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2],
             ],
             [
                 $trav([[], [null]]),
-                []
+                null,
+                [],
+            ],
+            [
+                $trav([[], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([[], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $trav([[null], []]),
-                []
+                null,
+                [],
+            ],
+            [
+                $trav([[null], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([[null], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $trav([[null], [null]]),
-                [null]
+                null,
+                [null],
+            ],
+            [
+                $trav([[null], [null]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [null],
+            ],
+            [
+                $trav([[null], [null]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [null],
             ],
             [
                 $trav([[1, 2], [2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $trav([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $trav([[1, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 2],
             ],
             [
                 $trav([[3, 2], [2]]),
-                [2]
+                null,
+                [2],
+            ],
+            [
+                $trav([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [2],
+            ],
+            [
+                $trav([[3, 2], [2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, 2],
             ],
             [
                 $trav([[1, 2], [2, 1]]),
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                $trav([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $trav([[1, 2], [2, 1]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
             ],
             [
                 $trav([[2, 1], [1, 2]]),
-                [1, 2]
+                null,
+                [1, 2],
+            ],
+            [
+                $trav([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $trav([[2, 1], [1, 2]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
             ],
             [
                 $trav([['a'], ['b']]),
-                ['a']
+                null,
+                ['a'],
+            ],
+            [
+                $trav([['a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['a'],
+            ],
+            [
+                $trav([['a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['b'],
             ],
             [
                 $trav([['a', 'a'], ['b']]),
-                ['b']
+                null,
+                ['b'],
+            ],
+            [
+                $trav([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                ['b'],
+            ],
+            [
+                $trav([['a', 'a'], ['b']]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                ['a', 'a'],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                null,
+                [1, 2, 3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2, 3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1, 3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [2, 0, 3],
+            ],
+            [
+                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [1, 2, 3],
             ],
         ];
     }

--- a/tests/Reduce/ToMinTest.php
+++ b/tests/Reduce/ToMinTest.php
@@ -15,13 +15,13 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @test         toMin array
      * @dataProvider dataProviderForArray
      * @param        array $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        int|float $expected
      */
-    public function testArray(array $data, ?callable $comparator, $expected): void
+    public function testArray(array $data, ?callable $compareBy, $expected): void
     {
         // When
-        $result = Reduce::toMin($data, $comparator);
+        $result = Reduce::toMin($data, $compareBy);
 
         // Then
         $this->assertSame($expected, $result);
@@ -457,13 +457,13 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @test         toMin generators
      * @dataProvider dataProviderForGenerators
      * @param        \Generator $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        mixed $expected
      */
-    public function testGenerators(\Generator $data, ?callable $comparator, $expected): void
+    public function testGenerators(\Generator $data, ?callable $compareBy, $expected): void
     {
         // When
-        $result = Reduce::toMin($data, $comparator);
+        $result = Reduce::toMin($data, $compareBy);
 
         // Then
         $this->assertSame($expected, $result);
@@ -903,13 +903,13 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @test         toMin iterators
      * @dataProvider dataProviderForIterators
      * @param        \Generator $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        mixed $expected
      */
-    public function testIterators(\Iterator $data, ?callable $comparator, $expected): void
+    public function testIterators(\Iterator $data, ?callable $compareBy, $expected): void
     {
         // When
-        $result = Reduce::toMin($data, $comparator);
+        $result = Reduce::toMin($data, $compareBy);
 
         // Then
         $this->assertSame($expected, $result);
@@ -1349,13 +1349,13 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @test         toMin traversables
      * @dataProvider dataProviderForTraversables
      * @param        \Traversable $data
-     * @param        callable|null $comparator
+     * @param        callable|null $compareBy
      * @param        mixed $expected
      */
-    public function testTraversables(\Traversable $data, ?callable $comparator, $expected): void
+    public function testTraversables(\Traversable $data, ?callable $compareBy, $expected): void
     {
         // When
-        $result = Reduce::toMin($data, $comparator);
+        $result = Reduce::toMin($data, $compareBy);
 
         // Then
         $this->assertSame($expected, $result);
@@ -1787,6 +1787,60 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
                 fn ($item) => -$item[1],
                 [1, 2, 3],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForUsingClassMethodToCompare
+     * @param iterable $data
+     * @param callable|null $compareBy
+     * @param $expected
+     * @return void
+     */
+    public function testUsingClassMethodToCompare(iterable $data, ?callable $compareBy, $expected): void
+    {
+        // When
+        $result = Reduce::toMin($data, $compareBy);
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+
+    public function dataProviderForUsingClassMethodToCompare(): array
+    {
+        $helper = new class () {
+            public function direct(int $value): int
+            {
+                return $value;
+            }
+
+            public function reverse(int $value): int
+            {
+                return -$value;
+            }
+        };
+
+        return [
+            [
+                [1, 3, 2, 5, 0],
+                fn ($item) => $helper->direct($item),
+                0,
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                fn ($item) => $helper->reverse($item),
+                5,
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                [$helper, 'direct'],
+                0,
+            ],
+            [
+                [1, 3, 2, 5, 0],
+                [$helper, 'reverse'],
+                5,
             ],
         ];
     }

--- a/tests/Reduce/ToMinTest.php
+++ b/tests/Reduce/ToMinTest.php
@@ -37,12 +37,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 null,
             ],
             [
                 [],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 null,
             ],
             [
@@ -52,12 +52,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [0],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 0,
             ],
             [
                 [0],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 0,
             ],
             [
@@ -67,12 +67,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [INF],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 [INF],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -82,12 +82,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [-INF],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 [-INF],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -97,12 +97,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [INF, -INF],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 [INF, -INF],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -112,12 +112,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [INF, -INF, 10, -1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 [INF, -INF, 10, -1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -127,12 +127,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [1, 2, 3],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 [1, 2, 3],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -142,12 +142,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [3, 2, 1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 [3, 2, 1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -157,12 +157,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [3, 2, 1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 [3, 2, 1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -172,12 +172,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2.1, 1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 [2.1, 1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.1,
             ],
             [
@@ -187,12 +187,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2, 1.1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 [2, 1.1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2,
             ],
             [
@@ -202,12 +202,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [2.2, 1.1],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 [2.2, 1.1],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.2,
             ],
             [
@@ -217,12 +217,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [1.1, 2.2],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 [1.1, 2.2],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.2,
             ],
             [
@@ -232,12 +232,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['a', 'b', 'c'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 ['a', 'b', 'c'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -247,12 +247,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['b', 'c', 'a'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 ['b', 'c', 'a'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -262,12 +262,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['c', 'b', 'a'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 ['c', 'b', 'a'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -277,13 +277,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['ab', 'ba', 'b'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ab',
-            ],
-            [
-                ['ab', 'ba', 'b'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ba',
             ],
             [
                 ['ba', 'b', 'ab'],
@@ -292,13 +287,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['ba', 'b', 'ab'],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ab',
-            ],
-            [
-                ['ba', 'b', 'ab'],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ba',
             ],
             [
                 [[]],
@@ -307,12 +297,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                [[]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -322,12 +307,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [2],
-            ],
-            [
-                [[2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
@@ -337,12 +317,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[], []],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                [[], []],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -352,13 +327,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[], [2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                [[], [2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 [[2], []],
@@ -367,13 +337,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[2], []],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                [[2], []],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 [[], [null]],
@@ -382,13 +347,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[], [null]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                [[], [null]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [null],
             ],
             [
                 [[null], []],
@@ -397,13 +357,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[null], []],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                [[null], []],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [null],
             ],
             [
                 [[null], [null]],
@@ -412,12 +367,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[null], [null]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [null],
-            ],
-            [
-                [[null], [null]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [null],
             ],
             [
@@ -427,13 +377,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[1, 2], [2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
-            ],
-            [
-                [[1, 2], [2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 [[3, 2], [2]],
@@ -442,28 +387,18 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[3, 2], [2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
-                [[3, 2], [2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [3, 2],
-            ],
-            [
                 [[1, 2], [2, 1]],
                 null,
                 [1, 2],
             ],
             [
                 [[1, 2], [2, 1]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                [[1, 2], [2, 1]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1],
             ],
             [
                 [[2, 1], [1, 2]],
@@ -472,13 +407,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[2, 1], [1, 2]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                [[2, 1], [1, 2]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1],
             ],
             [
                 [['a'], ['b']],
@@ -487,28 +417,18 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [['a'], ['b']],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['a'],
             ],
             [
-                [['a'], ['b']],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['b'],
-            ],
-            [
                 [['a', 'a'], ['b']],
                 null,
                 ['b'],
             ],
             [
                 [['a', 'a'], ['b']],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['b'],
-            ],
-            [
-                [['a', 'a'], ['b']],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['a', 'a'],
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
@@ -517,22 +437,17 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2, 3],
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1, 3],
-            ],
-            [
-                [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                fn ($item) => $item[1],
                 [2, 0, 3],
             ],
             [
                 [[1, 2, 3], [2, 0, 3], [2, 1, 3]],
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [1, 2, 3],
             ],
         ];
@@ -568,12 +483,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 null,
             ],
             [
                 $gen([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 null,
             ],
             [
@@ -583,12 +498,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 0,
             ],
             [
                 $gen([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 0,
             ],
             [
@@ -598,12 +513,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $gen([INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -613,12 +528,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([-INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $gen([-INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -628,12 +543,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([INF, -INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $gen([INF, -INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -643,12 +558,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $gen([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -658,12 +573,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([1, 2, 3]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $gen([1, 2, 3]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -673,12 +588,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $gen([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -688,12 +603,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $gen([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -703,12 +618,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2.1, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $gen([2.1, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.1,
             ],
             [
@@ -718,12 +633,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $gen([2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2,
             ],
             [
@@ -733,12 +648,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([2.2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $gen([2.2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.2,
             ],
             [
@@ -748,12 +663,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([1.1, 2.2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $gen([1.1, 2.2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.2,
             ],
             [
@@ -763,12 +678,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $gen(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -778,12 +693,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $gen(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -793,12 +708,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $gen(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -808,13 +723,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ab',
-            ],
-            [
-                $gen(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ba',
             ],
             [
                 $gen(['ba', 'b', 'ab']),
@@ -823,13 +733,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ab',
-            ],
-            [
-                $gen(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ba',
             ],
             [
                 $gen([[]]),
@@ -838,12 +743,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $gen([[]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -853,12 +753,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [2],
-            ],
-            [
-                $gen([[2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
@@ -868,12 +763,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $gen([[], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -883,13 +773,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $gen([[], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $gen([[2], []]),
@@ -898,13 +783,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[2], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $gen([[2], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $gen([[], [null]]),
@@ -913,13 +793,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $gen([[], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [null],
             ],
             [
                 $gen([[null], []]),
@@ -928,13 +803,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[null], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $gen([[null], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [null],
             ],
             [
                 $gen([[null], [null]]),
@@ -943,12 +813,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[null], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [null],
-            ],
-            [
-                $gen([[null], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [null],
             ],
             [
@@ -958,13 +823,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
-            ],
-            [
-                $gen([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $gen([[3, 2], [2]]),
@@ -973,28 +833,18 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
-                $gen([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [3, 2],
-            ],
-            [
                 $gen([[1, 2], [2, 1]]),
                 null,
                 [1, 2],
             ],
             [
                 $gen([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $gen([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1],
             ],
             [
                 $gen([[2, 1], [1, 2]]),
@@ -1003,13 +853,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $gen([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1],
             ],
             [
                 $gen([['a'], ['b']]),
@@ -1018,28 +863,18 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([['a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['a'],
             ],
             [
-                $gen([['a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['b'],
-            ],
-            [
                 $gen([['a', 'a'], ['b']]),
                 null,
                 ['b'],
             ],
             [
                 $gen([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['b'],
-            ],
-            [
-                $gen([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['a', 'a'],
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
@@ -1048,22 +883,17 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2, 3],
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1, 3],
-            ],
-            [
-                $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                fn ($item) => $item[1],
                 [2, 0, 3],
             ],
             [
                 $gen([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [1, 2, 3],
             ],
         ];
@@ -1099,12 +929,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 null,
             ],
             [
                 $iter([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 null,
             ],
             [
@@ -1114,12 +944,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 0,
             ],
             [
                 $iter([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 0,
             ],
             [
@@ -1129,12 +959,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $iter([INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -1144,12 +974,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([-INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $iter([-INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -1159,12 +989,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([INF, -INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $iter([INF, -INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -1174,12 +1004,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $iter([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -1189,12 +1019,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([1, 2, 3]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $iter([1, 2, 3]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -1204,12 +1034,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $iter([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -1219,12 +1049,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $iter([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -1234,12 +1064,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([2.1, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $iter([2.1, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.1,
             ],
             [
@@ -1249,12 +1079,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $iter([2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2,
             ],
             [
@@ -1264,12 +1094,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([2.2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $iter([2.2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.2,
             ],
             [
@@ -1279,12 +1109,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([1.1, 2.2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $iter([1.1, 2.2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.2,
             ],
             [
@@ -1294,12 +1124,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $iter(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -1309,12 +1139,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $iter(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -1324,12 +1154,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $iter(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -1339,13 +1169,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ab',
-            ],
-            [
-                $iter(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ba',
             ],
             [
                 $iter(['ba', 'b', 'ab']),
@@ -1354,13 +1179,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ab',
-            ],
-            [
-                $iter(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ba',
             ],
             [
                 $iter([[]]),
@@ -1369,12 +1189,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $iter([[]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -1384,12 +1199,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [2],
-            ],
-            [
-                $iter([[2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
@@ -1399,12 +1209,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $iter([[], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -1414,13 +1219,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $iter([[], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $iter([[2], []]),
@@ -1429,13 +1229,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[2], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $iter([[2], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $iter([[], [null]]),
@@ -1444,13 +1239,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $iter([[], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [null],
             ],
             [
                 $iter([[null], []]),
@@ -1459,13 +1249,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[null], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $iter([[null], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [null],
             ],
             [
                 $iter([[null], [null]]),
@@ -1474,12 +1259,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[null], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [null],
-            ],
-            [
-                $iter([[null], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [null],
             ],
             [
@@ -1489,13 +1269,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
-            ],
-            [
-                $iter([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $iter([[3, 2], [2]]),
@@ -1504,28 +1279,18 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
-                $iter([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [3, 2],
-            ],
-            [
                 $iter([[1, 2], [2, 1]]),
                 null,
                 [1, 2],
             ],
             [
                 $iter([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $iter([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1],
             ],
             [
                 $iter([[2, 1], [1, 2]]),
@@ -1534,13 +1299,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $iter([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1],
             ],
             [
                 $iter([['a'], ['b']]),
@@ -1549,28 +1309,18 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([['a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['a'],
             ],
             [
-                $iter([['a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['b'],
-            ],
-            [
                 $iter([['a', 'a'], ['b']]),
                 null,
                 ['b'],
             ],
             [
                 $iter([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['b'],
-            ],
-            [
-                $iter([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['a', 'a'],
             ],
             [
                 $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
@@ -1579,22 +1329,17 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2, 3],
             ],
             [
                 $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1, 3],
-            ],
-            [
-                $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                fn ($item) => $item[1],
                 [2, 0, 3],
             ],
             [
                 $iter([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [1, 2, 3],
             ],
         ];
@@ -1630,12 +1375,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 null,
             ],
             [
                 $trav([]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 null,
             ],
             [
@@ -1645,12 +1390,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([0]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 0,
             ],
             [
                 $trav([0]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 0,
             ],
             [
@@ -1660,12 +1405,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 INF,
             ],
             [
                 $trav([INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -1675,12 +1420,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([-INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $trav([-INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 -INF,
             ],
             [
@@ -1690,12 +1435,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([INF, -INF]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $trav([INF, -INF]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -1705,12 +1450,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 -INF,
             ],
             [
                 $trav([INF, -INF, 10, -1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 INF,
             ],
             [
@@ -1720,12 +1465,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([1, 2, 3]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $trav([1, 2, 3]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -1735,12 +1480,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $trav([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -1750,12 +1495,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([3, 2, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $trav([3, 2, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 3,
             ],
             [
@@ -1765,12 +1510,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2.1, 1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1,
             ],
             [
                 $trav([2.1, 1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.1,
             ],
             [
@@ -1780,12 +1525,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $trav([2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2,
             ],
             [
@@ -1795,12 +1540,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([2.2, 1.1]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $trav([2.2, 1.1]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.2,
             ],
             [
@@ -1810,12 +1555,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([1.1, 2.2]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 1.1,
             ],
             [
                 $trav([1.1, 2.2]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -$item,
                 2.2,
             ],
             [
@@ -1825,12 +1570,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $trav(['a', 'b', 'c']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -1840,12 +1585,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $trav(['b', 'c', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -1855,12 +1600,12 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'a',
             ],
             [
                 $trav(['c', 'b', 'a']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => -ord($item),
                 'c',
             ],
             [
@@ -1870,13 +1615,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ab',
-            ],
-            [
-                $trav(['ab', 'ba', 'b']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ba',
             ],
             [
                 $trav(['ba', 'b', 'ab']),
@@ -1885,13 +1625,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 'ab',
-            ],
-            [
-                $trav(['ba', 'b', 'ab']),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                'ba',
             ],
             [
                 $trav([[]]),
@@ -1900,12 +1635,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $trav([[]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -1915,12 +1645,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [2],
-            ],
-            [
-                $trav([[2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
@@ -1930,12 +1655,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [],
-            ],
-            [
-                $trav([[], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [],
             ],
             [
@@ -1945,13 +1665,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $trav([[], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $trav([[2], []]),
@@ -1960,13 +1675,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[2], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $trav([[2], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2],
             ],
             [
                 $trav([[], [null]]),
@@ -1975,13 +1685,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $trav([[], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [null],
             ],
             [
                 $trav([[null], []]),
@@ -1990,13 +1695,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[null], []]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [],
-            ],
-            [
-                $trav([[null], []]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [null],
             ],
             [
                 $trav([[null], [null]]),
@@ -2005,12 +1705,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[null], [null]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
-                [null],
-            ],
-            [
-                $trav([[null], [null]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                fn ($item) => $item,
                 [null],
             ],
             [
@@ -2020,13 +1715,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
-            ],
-            [
-                $trav([[1, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [1, 2],
             ],
             [
                 $trav([[3, 2], [2]]),
@@ -2035,28 +1725,18 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [2],
             ],
             [
-                $trav([[3, 2], [2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [3, 2],
-            ],
-            [
                 $trav([[1, 2], [2, 1]]),
                 null,
                 [1, 2],
             ],
             [
                 $trav([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $trav([[1, 2], [2, 1]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1],
             ],
             [
                 $trav([[2, 1], [1, 2]]),
@@ -2065,13 +1745,8 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2],
-            ],
-            [
-                $trav([[2, 1], [1, 2]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1],
             ],
             [
                 $trav([['a'], ['b']]),
@@ -2080,28 +1755,18 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([['a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['a'],
             ],
             [
-                $trav([['a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['b'],
-            ],
-            [
                 $trav([['a', 'a'], ['b']]),
                 null,
                 ['b'],
             ],
             [
                 $trav([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 ['b'],
-            ],
-            [
-                $trav([['a', 'a'], ['b']]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                ['a', 'a'],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
@@ -2110,22 +1775,17 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                fn ($item) => $item,
                 [1, 2, 3],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs <=> $lhs,
-                [2, 1, 3],
-            ],
-            [
-                $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                fn ($item) => $item[1],
                 [2, 0, 3],
             ],
             [
                 $trav([[1, 2, 3], [2, 0, 3], [2, 1, 3]]),
-                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                fn ($item) => -$item[1],
                 [1, 2, 3],
             ],
         ];

--- a/tests/Reduce/ToMinTest.php
+++ b/tests/Reduce/ToMinTest.php
@@ -18,7 +18,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @param        callable|null $comparator
      * @param        int|float $expected
      */
-    public function testArray(array $data, ?callable $comparator, $expected)
+    public function testArray(array $data, ?callable $comparator, $expected): void
     {
         // When
         $result = Reduce::toMin($data, $comparator);
@@ -460,7 +460,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testGenerators(\Generator $data, ?callable $comparator, $expected)
+    public function testGenerators(\Generator $data, ?callable $comparator, $expected): void
     {
         // When
         $result = Reduce::toMin($data, $comparator);
@@ -906,7 +906,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testIterators(\Iterator $data, ?callable $comparator, $expected)
+    public function testIterators(\Iterator $data, ?callable $comparator, $expected): void
     {
         // When
         $result = Reduce::toMin($data, $comparator);
@@ -1352,7 +1352,7 @@ class ToMinTest extends \PHPUnit\Framework\TestCase
      * @param        callable|null $comparator
      * @param        mixed $expected
      */
-    public function testTraversables(\Traversable $data, ?callable $comparator, $expected)
+    public function testTraversables(\Traversable $data, ?callable $comparator, $expected): void
     {
         // When
         $result = Reduce::toMin($data, $comparator);

--- a/tests/Single/SortTest.php
+++ b/tests/Single/SortTest.php
@@ -1,0 +1,883 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IterTools\Tests\Single;
+
+use IterTools\Single;
+use IterTools\Tests\Fixture\ArrayIteratorFixture;
+use IterTools\Tests\Fixture\GeneratorFixture;
+use IterTools\Tests\Fixture\IteratorAggregateFixture;
+
+class SortTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider dataProviderForArray
+     * @param array $data
+     * @param callable|null $comparator
+     * @param array $expected
+     */
+    public function testArray(array $data, ?callable $comparator, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Single::sort($data, $comparator) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEquals($expected, $result);
+    }
+
+    public function dataProviderForArray(): array
+    {
+        return [
+            [
+                [],
+                null,
+                [],
+            ],
+            [
+                [],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                [],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
+            ],
+            [
+                [1],
+                null,
+                [1],
+            ],
+            [
+                [1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1],
+            ],
+            [
+                [1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1],
+            ],
+            [
+                [1, 1],
+                null,
+                [1, 1],
+            ],
+            [
+                [1, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1],
+            ],
+            [
+                [1, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 1],
+            ],
+            [
+                [1, 2],
+                null,
+                [1, 2],
+            ],
+            [
+                [1, 2],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                [1, 2],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
+            ],
+            [
+                [2, 1],
+                null,
+                [1, 2],
+            ],
+            [
+                [2, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                [2, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
+            ],
+            [
+                [2, 1, 1],
+                null,
+                [1, 1, 2],
+            ],
+            [
+                [2, 1, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1, 2],
+            ],
+            [
+                [2, 1, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1, 1],
+            ],
+            [
+                [2, 1, 3],
+                null,
+                [1, 2, 3],
+            ],
+            [
+                [2, 1, 3],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2, 3],
+            ],
+            [
+                [2, 1, 3],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, 2, 1],
+            ],
+            [
+                [1, 3, 2, 5, -3, -6, 10, 11, 1],
+                null,
+                [-6, -3, 1, 1, 2, 3, 5, 10, 11],
+            ],
+            [
+                [1, 3, 2, 5, -3, -6, 10, 11, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-6, -3, 1, 1, 2, 3, 5, 10, 11],
+            ],
+            [
+                [1, 3, 2, 5, -3, -6, 10, 11, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [11, 10, 5, 3, 2, 1, 1, -3, -6],
+            ],
+            [
+                [1, 3.3, 2, 5, -3.1, -6, '10', 11, 1],
+                null,
+                [-6, -3.1, 1, 1, 2, 3.3, 5, '10', 11],
+            ],
+            [
+                [1, 3.3, 2, 5, -3.1, -6, '10', 11, 1],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-6, -3.1, 1, 1, 2, 3.3, 5, '10', 11],
+            ],
+            [
+                [1, 3.3, 2, 5, -3.1, -6, '10', 11, 1],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [11, '10', 5, 3.3, 2, 1, 1, -3.1, -6]
+            ],
+            [
+                [true, false, false, true, false],
+                null,
+                [false, false, false, true, true],
+            ],
+            [
+                [true, false, false, true, false],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [false, false, false, true, true],
+            ],
+            [
+                [true, false, false, true, false],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [true, true, false, false, false],
+            ],
+            [
+                [[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []],
+                null,
+                [[], [-2], [0], [1], [3], [5.1], [1, 1], [2, 3]],
+            ],
+            [
+                [[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[], [-2], [0], [1], [3], [5.1], [1, 1], [2, 3]],
+            ],
+            [
+                [[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[2, 3], [1, 1], [5.1], [3], [1], [0], [-2], []],
+            ],
+            [
+                [[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]],
+                null,
+                [[0, 3], [1, 2], [2, 1], [2, 2], [2, 5], [3, 0], [5, 2]],
+            ],
+            [
+                [[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]],
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[0, 3], [1, 2], [2, 1], [2, 2], [2, 5], [3, 0], [5, 2]],
+            ],
+            [
+                [[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]],
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[5, 2], [3, 0], [2, 5], [2, 2], [2, 1], [1, 2], [0, 3]],
+            ],
+            [
+                [[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]],
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [[3, 0], [2, 1], [1, 2], [2, 2], [5, 2], [0, 3], [2, 5]],
+            ],
+            [
+                [[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]],
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [[2, 5], [0, 3], [1, 2], [2, 2], [5, 2], [2, 1], [3, 0]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForGenerators
+     * @param \Generator $data
+     * @param callable|null $comparator
+     * @param array $expected
+     */
+    public function testGenerators(\Generator $data, ?callable $comparator, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Single::sort($data, $comparator) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEquals($expected, $result);
+    }
+
+    public function dataProviderForGenerators(): array
+    {
+        $gen = fn (array $data) => GeneratorFixture::getGenerator($data);
+
+        return [
+            [
+                $gen([]),
+                null,
+                [],
+            ],
+            [
+                $gen([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $gen([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
+            ],
+            [
+                $gen([1]),
+                null,
+                [1],
+            ],
+            [
+                $gen([1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1],
+            ],
+            [
+                $gen([1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1],
+            ],
+            [
+                $gen([1, 1]),
+                null,
+                [1, 1],
+            ],
+            [
+                $gen([1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1],
+            ],
+            [
+                $gen([1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 1],
+            ],
+            [
+                $gen([1, 2]),
+                null,
+                [1, 2],
+            ],
+            [
+                $gen([1, 2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $gen([1, 2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
+            ],
+            [
+                $gen([2, 1]),
+                null,
+                [1, 2],
+            ],
+            [
+                $gen([2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $gen([2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
+            ],
+            [
+                $gen([2, 1, 1]),
+                null,
+                [1, 1, 2],
+            ],
+            [
+                $gen([2, 1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1, 2],
+            ],
+            [
+                $gen([2, 1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1, 1],
+            ],
+            [
+                $gen([2, 1, 3]),
+                null,
+                [1, 2, 3],
+            ],
+            [
+                $gen([2, 1, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2, 3],
+            ],
+            [
+                $gen([2, 1, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, 2, 1],
+            ],
+            [
+                $gen([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                null,
+                [-6, -3, 1, 1, 2, 3, 5, 10, 11],
+            ],
+            [
+                $gen([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-6, -3, 1, 1, 2, 3, 5, 10, 11],
+            ],
+            [
+                $gen([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [11, 10, 5, 3, 2, 1, 1, -3, -6],
+            ],
+            [
+                $gen([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                null,
+                [-6, -3.1, 1, 1, 2, 3.3, 5, '10', 11],
+            ],
+            [
+                $gen([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-6, -3.1, 1, 1, 2, 3.3, 5, '10', 11],
+            ],
+            [
+                $gen([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [11, '10', 5, 3.3, 2, 1, 1, -3.1, -6]
+            ],
+            [
+                $gen([true, false, false, true, false]),
+                null,
+                [false, false, false, true, true],
+            ],
+            [
+                $gen([true, false, false, true, false]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [false, false, false, true, true],
+            ],
+            [
+                $gen([true, false, false, true, false]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [true, true, false, false, false],
+            ],
+            [
+                $gen([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                null,
+                [[], [-2], [0], [1], [3], [5.1], [1, 1], [2, 3]],
+            ],
+            [
+                $gen([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[], [-2], [0], [1], [3], [5.1], [1, 1], [2, 3]],
+            ],
+            [
+                $gen([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[2, 3], [1, 1], [5.1], [3], [1], [0], [-2], []],
+            ],
+            [
+                $gen([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                null,
+                [[0, 3], [1, 2], [2, 1], [2, 2], [2, 5], [3, 0], [5, 2]],
+            ],
+            [
+                $gen([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[0, 3], [1, 2], [2, 1], [2, 2], [2, 5], [3, 0], [5, 2]],
+            ],
+            [
+                $gen([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[5, 2], [3, 0], [2, 5], [2, 2], [2, 1], [1, 2], [0, 3]],
+            ],
+            [
+                $gen([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [[3, 0], [2, 1], [1, 2], [2, 2], [5, 2], [0, 3], [2, 5]],
+            ],
+            [
+                $gen([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [[2, 5], [0, 3], [1, 2], [2, 2], [5, 2], [2, 1], [3, 0]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIterators
+     * @param \Iterator $data
+     * @param callable|null $comparator
+     * @param array $expected
+     */
+    public function testIterators(\Iterator $data, ?callable $comparator, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Single::sort($data, $comparator) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEquals($expected, $result);
+    }
+
+    public function dataProviderForIterators(): array
+    {
+        $iter = fn (array $data) => new ArrayIteratorFixture($data);
+
+        return [
+            [
+                $iter([]),
+                null,
+                [],
+            ],
+            [
+                $iter([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $iter([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
+            ],
+            [
+                $iter([1]),
+                null,
+                [1],
+            ],
+            [
+                $iter([1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1],
+            ],
+            [
+                $iter([1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1],
+            ],
+            [
+                $iter([1, 1]),
+                null,
+                [1, 1],
+            ],
+            [
+                $iter([1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1],
+            ],
+            [
+                $iter([1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 1],
+            ],
+            [
+                $iter([1, 2]),
+                null,
+                [1, 2],
+            ],
+            [
+                $iter([1, 2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $iter([1, 2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
+            ],
+            [
+                $iter([2, 1]),
+                null,
+                [1, 2],
+            ],
+            [
+                $iter([2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $iter([2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
+            ],
+            [
+                $iter([2, 1, 1]),
+                null,
+                [1, 1, 2],
+            ],
+            [
+                $iter([2, 1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1, 2],
+            ],
+            [
+                $iter([2, 1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1, 1],
+            ],
+            [
+                $iter([2, 1, 3]),
+                null,
+                [1, 2, 3],
+            ],
+            [
+                $iter([2, 1, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2, 3],
+            ],
+            [
+                $iter([2, 1, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, 2, 1],
+            ],
+            [
+                $iter([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                null,
+                [-6, -3, 1, 1, 2, 3, 5, 10, 11],
+            ],
+            [
+                $iter([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-6, -3, 1, 1, 2, 3, 5, 10, 11],
+            ],
+            [
+                $iter([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [11, 10, 5, 3, 2, 1, 1, -3, -6],
+            ],
+            [
+                $iter([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                null,
+                [-6, -3.1, 1, 1, 2, 3.3, 5, '10', 11],
+            ],
+            [
+                $iter([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-6, -3.1, 1, 1, 2, 3.3, 5, '10', 11],
+            ],
+            [
+                $iter([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [11, '10', 5, 3.3, 2, 1, 1, -3.1, -6]
+            ],
+            [
+                $iter([true, false, false, true, false]),
+                null,
+                [false, false, false, true, true],
+            ],
+            [
+                $iter([true, false, false, true, false]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [false, false, false, true, true],
+            ],
+            [
+                $iter([true, false, false, true, false]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [true, true, false, false, false],
+            ],
+            [
+                $iter([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                null,
+                [[], [-2], [0], [1], [3], [5.1], [1, 1], [2, 3]],
+            ],
+            [
+                $iter([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[], [-2], [0], [1], [3], [5.1], [1, 1], [2, 3]],
+            ],
+            [
+                $iter([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[2, 3], [1, 1], [5.1], [3], [1], [0], [-2], []],
+            ],
+            [
+                $iter([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                null,
+                [[0, 3], [1, 2], [2, 1], [2, 2], [2, 5], [3, 0], [5, 2]],
+            ],
+            [
+                $iter([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[0, 3], [1, 2], [2, 1], [2, 2], [2, 5], [3, 0], [5, 2]],
+            ],
+            [
+                $iter([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[5, 2], [3, 0], [2, 5], [2, 2], [2, 1], [1, 2], [0, 3]],
+            ],
+            [
+                $iter([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [[3, 0], [2, 1], [1, 2], [2, 2], [5, 2], [0, 3], [2, 5]],
+            ],
+            [
+                $iter([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [[2, 5], [0, 3], [1, 2], [2, 2], [5, 2], [2, 1], [3, 0]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTraversables
+     * @param \Traversable $data
+     * @param callable|null $comparator
+     * @param array $expected
+     */
+    public function testTraversables(\Traversable $data, ?callable $comparator, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Single::sort($data, $comparator) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEquals($expected, $result);
+    }
+
+    public function dataProviderForTraversables(): array
+    {
+        $trav = fn (array $data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                $trav([]),
+                null,
+                [],
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [],
+            ],
+            [
+                $trav([]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [],
+            ],
+            [
+                $trav([1]),
+                null,
+                [1],
+            ],
+            [
+                $trav([1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1],
+            ],
+            [
+                $trav([1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1],
+            ],
+            [
+                $trav([1, 1]),
+                null,
+                [1, 1],
+            ],
+            [
+                $trav([1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1],
+            ],
+            [
+                $trav([1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [1, 1],
+            ],
+            [
+                $trav([1, 2]),
+                null,
+                [1, 2],
+            ],
+            [
+                $trav([1, 2]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $trav([1, 2]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
+            ],
+            [
+                $trav([2, 1]),
+                null,
+                [1, 2],
+            ],
+            [
+                $trav([2, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2],
+            ],
+            [
+                $trav([2, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1],
+            ],
+            [
+                $trav([2, 1, 1]),
+                null,
+                [1, 1, 2],
+            ],
+            [
+                $trav([2, 1, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 1, 2],
+            ],
+            [
+                $trav([2, 1, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [2, 1, 1],
+            ],
+            [
+                $trav([2, 1, 3]),
+                null,
+                [1, 2, 3],
+            ],
+            [
+                $trav([2, 1, 3]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [1, 2, 3],
+            ],
+            [
+                $trav([2, 1, 3]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [3, 2, 1],
+            ],
+            [
+                $trav([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                null,
+                [-6, -3, 1, 1, 2, 3, 5, 10, 11],
+            ],
+            [
+                $trav([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-6, -3, 1, 1, 2, 3, 5, 10, 11],
+            ],
+            [
+                $trav([1, 3, 2, 5, -3, -6, 10, 11, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [11, 10, 5, 3, 2, 1, 1, -3, -6],
+            ],
+            [
+                $trav([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                null,
+                [-6, -3.1, 1, 1, 2, 3.3, 5, '10', 11],
+            ],
+            [
+                $trav([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [-6, -3.1, 1, 1, 2, 3.3, 5, '10', 11],
+            ],
+            [
+                $trav([1, 3.3, 2, 5, -3.1, -6, '10', 11, 1]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [11, '10', 5, 3.3, 2, 1, 1, -3.1, -6]
+            ],
+            [
+                $trav([true, false, false, true, false]),
+                null,
+                [false, false, false, true, true],
+            ],
+            [
+                $trav([true, false, false, true, false]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [false, false, false, true, true],
+            ],
+            [
+                $trav([true, false, false, true, false]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [true, true, false, false, false],
+            ],
+            [
+                $trav([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                null,
+                [[], [-2], [0], [1], [3], [5.1], [1, 1], [2, 3]],
+            ],
+            [
+                $trav([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[], [-2], [0], [1], [3], [5.1], [1, 1], [2, 3]],
+            ],
+            [
+                $trav([[1], [3], [-2], [5.1], [2, 3], [1, 1], [0], []]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[2, 3], [1, 1], [5.1], [3], [1], [0], [-2], []],
+            ],
+            [
+                $trav([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                null,
+                [[0, 3], [1, 2], [2, 1], [2, 2], [2, 5], [3, 0], [5, 2]],
+            ],
+            [
+                $trav([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $lhs <=> $rhs,
+                [[0, 3], [1, 2], [2, 1], [2, 2], [2, 5], [3, 0], [5, 2]],
+            ],
+            [
+                $trav([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $rhs <=> $lhs,
+                [[5, 2], [3, 0], [2, 5], [2, 2], [2, 1], [1, 2], [0, 3]],
+            ],
+            [
+                $trav([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $lhs[1] <=> $rhs[1],
+                [[3, 0], [2, 1], [1, 2], [2, 2], [5, 2], [0, 3], [2, 5]],
+            ],
+            [
+                $trav([[1, 2], [2, 1], [2, 2], [3, 0], [0, 3], [5, 2], [2, 5]]),
+                fn ($lhs, $rhs) => $rhs[1] <=> $lhs[1],
+                [[2, 5], [0, 3], [1, 2], [2, 2], [5, 2], [2, 1], [3, 0]],
+            ],
+        ];
+    }
+}

--- a/tests/Stream/ReduceTest.php
+++ b/tests/Stream/ReduceTest.php
@@ -641,6 +641,69 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->toRange(),
                 13,
             ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toFirst(),
+                -3,
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toFirst(),
+                -3,
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toFirst(),
+                7,
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toLast(),
+                7,
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toLast(),
+                7,
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toLast(),
+                -3,
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toFirstAndLast(),
+                [-3, 7],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toFirstAndLast(),
+                [-3, 7],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toFirstAndLast(),
+                [7, -3],
+            ],
         ];
     }
 
@@ -1199,6 +1262,69 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->chainWith([6, 10, 4])
                     ->toRange(),
                 13,
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toFirst(),
+                -3,
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toFirst(),
+                -3,
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toFirst(),
+                7,
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toLast(),
+                7,
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toLast(),
+                7,
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toLast(),
+                -3,
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toFirstAndLast(),
+                [-3, 7],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toFirstAndLast(),
+                [-3, 7],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toFirstAndLast(),
+                [7, -3],
             ],
         ];
     }
@@ -1759,6 +1885,69 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->toRange(),
                 13,
             ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toFirst(),
+                -3,
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toFirst(),
+                -3,
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toFirst(),
+                7,
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toLast(),
+                7,
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toLast(),
+                7,
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toLast(),
+                -3,
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toFirstAndLast(),
+                [-3, 7],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toFirstAndLast(),
+                [-3, 7],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toFirstAndLast(),
+                [7, -3],
+            ],
         ];
     }
 
@@ -2317,6 +2506,69 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->chainWith([6, 10, 4])
                     ->toRange(),
                 13,
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toFirst(),
+                -3,
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toFirst(),
+                -3,
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toFirst(),
+                7,
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toLast(),
+                7,
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toLast(),
+                7,
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toLast(),
+                -3,
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toFirstAndLast(),
+                [-3, 7],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toFirstAndLast(),
+                [-3, 7],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toFirstAndLast(),
+                [7, -3],
             ],
         ];
     }

--- a/tests/Stream/ReduceTest.php
+++ b/tests/Stream/ReduceTest.php
@@ -145,22 +145,22 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [],
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => $item),
                 null,
             ],
             [
                 [],
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => -$item),
                 null,
             ],
             [
                 [1, -1, 2, -2, 3, -3],
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => $item),
                 3,
             ],
             [
                 [1, -1, 2, -2, 3, -3],
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => -$item),
                 -3,
             ],
             [
@@ -203,12 +203,12 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [],
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => $item),
                 null,
             ],
             [
                 [],
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => -$item),
                 null,
             ],
             [
@@ -218,12 +218,12 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [1, -1, 2, -2, 3, -3],
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => $item),
                 -3,
             ],
             [
                 [1, -1, 2, -2, 3, -3],
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => -$item),
                 3,
             ],
             [
@@ -568,14 +568,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 [2, 3, 1, 2, -3, -2, 5, 7, 3],
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn () => false)
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [null, null],
             ],
             [
                 [2, 3, 1, 2, -3, -2, 5, 7, 3],
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn () => false)
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [null, null],
             ],
             [
@@ -589,14 +589,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 [2, 3, 1, 2, -3, -2, 5, 7, 3],
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [7, 7],
             ],
             [
                 [2, 3, 1, 2, -3, -2, 5, 7, 3],
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [7, 7],
             ],
             [
@@ -610,14 +610,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 [2, 3, 1, 2, -3, -2, 5, 7, 3],
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->chainWith([6, 10, 4])
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [-3, 10],
             ],
             [
                 [2, 3, 1, 2, -3, -2, 5, 7, 3],
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->chainWith([6, 10, 4])
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [10, -3],
             ],
             [
@@ -843,22 +843,22 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => $item),
                 null,
             ],
             [
                 $gen([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => -$item),
                 null,
             ],
             [
                 $gen([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => $item),
                 3,
             ],
             [
                 $gen([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => -$item),
                 -3,
             ],
             [
@@ -901,12 +901,12 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => $item),
                 null,
             ],
             [
                 $gen([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => -$item),
                 null,
             ],
             [
@@ -916,12 +916,12 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => $item),
                 -3,
             ],
             [
                 $gen([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => -$item),
                 3,
             ],
             [
@@ -1190,14 +1190,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn () => false)
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [null, null],
             ],
             [
                 $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn () => false)
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [null, null],
             ],
             [
@@ -1211,14 +1211,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [7, 7],
             ],
             [
                 $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [7, 7],
             ],
             [
@@ -1232,14 +1232,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->chainWith([6, 10, 4])
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [-3, 10],
             ],
             [
                 $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->chainWith([6, 10, 4])
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [10, -3],
             ],
             [
@@ -1465,22 +1465,22 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => $item),
                 null,
             ],
             [
                 $iter([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => -$item),
                 null,
             ],
             [
                 $iter([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => $item),
                 3,
             ],
             [
                 $iter([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => -$item),
                 -3,
             ],
             [
@@ -1523,12 +1523,12 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => $item),
                 null,
             ],
             [
                 $iter([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => -$item),
                 null,
             ],
             [
@@ -1538,12 +1538,12 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => $item),
                 -3,
             ],
             [
                 $iter([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => -$item),
                 3,
             ],
             [
@@ -1812,14 +1812,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn () => false)
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [null, null],
             ],
             [
                 $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn () => false)
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [null, null],
             ],
             [
@@ -1833,14 +1833,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [7, 7],
             ],
             [
                 $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [7, 7],
             ],
             [
@@ -1854,14 +1854,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->chainWith([6, 10, 4])
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [-3, 10],
             ],
             [
                 $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->chainWith([6, 10, 4])
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [10, -3],
             ],
             [
@@ -2087,22 +2087,22 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => $item),
                 null,
             ],
             [
                 $trav([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => -$item),
                 null,
             ],
             [
                 $trav([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => $item),
                 3,
             ],
             [
                 $trav([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($item) => -$item),
                 -3,
             ],
             [
@@ -2145,12 +2145,12 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => $item),
                 null,
             ],
             [
                 $trav([]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => -$item),
                 null,
             ],
             [
@@ -2160,12 +2160,12 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => $item),
                 -3,
             ],
             [
                 $trav([1, -1, 2, -2, 3, -3]),
-                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($item) => -$item),
                 3,
             ],
             [
@@ -2434,14 +2434,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn () => false)
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [null, null],
             ],
             [
                 $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn () => false)
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [null, null],
             ],
             [
@@ -2455,14 +2455,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [7, 7],
             ],
             [
                 $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [7, 7],
             ],
             [
@@ -2476,14 +2476,14 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->chainWith([6, 10, 4])
-                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                    ->toMinMax(fn ($item) => $item),
                 [-3, 10],
             ],
             [
                 $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->chainWith([6, 10, 4])
-                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                    ->toMinMax(fn ($item) => -$item),
                 [10, -3],
             ],
             [

--- a/tests/Stream/ReduceTest.php
+++ b/tests/Stream/ReduceTest.php
@@ -144,6 +144,26 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 null,
             ],
             [
+                [],
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                null,
+            ],
+            [
+                [],
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                null,
+            ],
+            [
+                [1, -1, 2, -2, 3, -3],
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                3,
+            ],
+            [
+                [1, -1, 2, -2, 3, -3],
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                -3,
+            ],
+            [
                 [1, -1, 2, -2, 3, -3],
                 fn (iterable $iterable) => Stream::of($iterable)->toMax(),
                 3,
@@ -182,9 +202,29 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 null,
             ],
             [
+                [],
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                null,
+            ],
+            [
+                [],
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                null,
+            ],
+            [
                 [1, -1, 2, -2, 3, -3],
                 fn (iterable $iterable) => Stream::of($iterable)->toMin(),
                 -3,
+            ],
+            [
+                [1, -1, 2, -2, 3, -3],
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                -3,
+            ],
+            [
+                [1, -1, 2, -2, 3, -3],
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                3,
             ],
             [
                 [],
@@ -527,8 +567,36 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             [
                 [2, 3, 1, 2, -3, -2, 5, 7, 3],
                 fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [null, null],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                [null, null],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
                     ->toMinMax(),
+                [7, 7],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($number) => $number > 6)
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [7, 7],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($number) => $number > 6)
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
                 [7, 7],
             ],
             [
@@ -537,6 +605,20 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->chainWith([6, 10, 4])
                     ->toMinMax(),
                 [-3, 10],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([6, 10, 4])
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [-3, 10],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([6, 10, 4])
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                [10, -3],
             ],
             [
                 [2, 3, 1, 2, -3, -2, 5, 7, 3],
@@ -697,6 +779,26 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 null,
             ],
             [
+                $gen([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                null,
+            ],
+            [
+                $gen([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                null,
+            ],
+            [
+                $gen([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                3,
+            ],
+            [
+                $gen([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                -3,
+            ],
+            [
                 $gen([1, -1, 2, -2, 3, -3]),
                 fn (iterable $iterable) => Stream::of($iterable)->toMax(),
                 3,
@@ -735,9 +837,29 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 null,
             ],
             [
+                $gen([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                null,
+            ],
+            [
+                $gen([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                null,
+            ],
+            [
                 $gen([1, -1, 2, -2, 3, -3]),
                 fn (iterable $iterable) => Stream::of($iterable)->toMin(),
                 -3,
+            ],
+            [
+                $gen([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                -3,
+            ],
+            [
+                $gen([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                3,
             ],
             [
                 $gen([]),
@@ -1004,8 +1126,36 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             [
                 $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [null, null],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                [null, null],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
                     ->toMinMax(),
+                [7, 7],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($number) => $number > 6)
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [7, 7],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($number) => $number > 6)
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
                 [7, 7],
             ],
             [
@@ -1014,6 +1164,20 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->chainWith([6, 10, 4])
                     ->toMinMax(),
                 [-3, 10],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([6, 10, 4])
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [-3, 10],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([6, 10, 4])
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                [10, -3],
             ],
             [
                 $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
@@ -1174,6 +1338,26 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 null,
             ],
             [
+                $iter([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                null,
+            ],
+            [
+                $iter([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                null,
+            ],
+            [
+                $iter([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                3,
+            ],
+            [
+                $iter([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                -3,
+            ],
+            [
                 $iter([1, -1, 2, -2, 3, -3]),
                 fn (iterable $iterable) => Stream::of($iterable)->toMax(),
                 3,
@@ -1212,9 +1396,29 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 null,
             ],
             [
+                $iter([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                null,
+            ],
+            [
+                $iter([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                null,
+            ],
+            [
                 $iter([1, -1, 2, -2, 3, -3]),
                 fn (iterable $iterable) => Stream::of($iterable)->toMin(),
                 -3,
+            ],
+            [
+                $iter([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                -3,
+            ],
+            [
+                $iter([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                3,
             ],
             [
                 $iter([]),
@@ -1481,8 +1685,36 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             [
                 $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [null, null],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                [null, null],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
                     ->toMinMax(),
+                [7, 7],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($number) => $number > 6)
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [7, 7],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($number) => $number > 6)
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
                 [7, 7],
             ],
             [
@@ -1491,6 +1723,20 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->chainWith([6, 10, 4])
                     ->toMinMax(),
                 [-3, 10],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([6, 10, 4])
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [-3, 10],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([6, 10, 4])
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                [10, -3],
             ],
             [
                 $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
@@ -1651,6 +1897,26 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 null,
             ],
             [
+                $trav([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                null,
+            ],
+            [
+                $trav([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                null,
+            ],
+            [
+                $trav([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                3,
+            ],
+            [
+                $trav([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                -3,
+            ],
+            [
                 $trav([1, -1, 2, -2, 3, -3]),
                 fn (iterable $iterable) => Stream::of($iterable)->toMax(),
                 3,
@@ -1689,9 +1955,29 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                 null,
             ],
             [
+                $trav([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                null,
+            ],
+            [
+                $trav([]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                null,
+            ],
+            [
                 $trav([1, -1, 2, -2, 3, -3]),
                 fn (iterable $iterable) => Stream::of($iterable)->toMin(),
                 -3,
+            ],
+            [
+                $trav([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                -3,
+            ],
+            [
+                $trav([1, -1, 2, -2, 3, -3]),
+                fn (iterable $iterable) => Stream::of($iterable)->toMin(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                3,
             ],
             [
                 $trav([]),
@@ -1958,8 +2244,36 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
             [
                 $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [null, null],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn () => false)
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                [null, null],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($number) => $number > 6)
                     ->toMinMax(),
+                [7, 7],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($number) => $number > 6)
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [7, 7],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($number) => $number > 6)
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
                 [7, 7],
             ],
             [
@@ -1968,6 +2282,20 @@ class ReduceTest extends \PHPUnit\Framework\TestCase
                     ->chainWith([6, 10, 4])
                     ->toMinMax(),
                 [-3, 10],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([6, 10, 4])
+                    ->toMinMax(fn ($lhs, $rhs) => $lhs <=> $rhs),
+                [-3, 10],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->chainWith([6, 10, 4])
+                    ->toMinMax(fn ($lhs, $rhs) => $rhs <=> $lhs),
+                [10, -3],
             ],
             [
                 $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),

--- a/tests/Stream/SingleTest.php
+++ b/tests/Stream/SingleTest.php
@@ -12,9 +12,9 @@ use IterTools\Tests\Fixture\IteratorAggregateFixture;
 class SingleTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @param array    $input
+     * @param array $input
      * @param callable $streamFactoryFunc
-     * @param array    $expected
+     * @param array $expected
      * @return void
      * @dataProvider dataProviderForArray
      */
@@ -433,13 +433,34 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(fn ($value, $key) => $key, fn ($value) => $value),
                 [0 => 1, '1' => 2, 2 => 3, '3' => 4, 4 => 5, 'a' => 11, 'b' => 22],
             ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toArray(),
+                [7, 5, 3, 3, 2, 2, 1, -2, -3],
+            ],
         ];
     }
 
     /**
      * @param \Generator $input
-     * @param callable   $streamFactoryFunc
-     * @param array      $expected
+     * @param callable $streamFactoryFunc
+     * @param array $expected
      * @return void
      * @dataProvider dataProviderForGenerator
      */
@@ -824,13 +845,34 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(fn ($value, $key) => $key, fn ($value) => $value),
                 [0 => 1, '1' => 2, 2 => 3, '3' => 4, 4 => 5, 'a' => 11, 'b' => 22],
             ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toArray(),
+                [7, 5, 3, 3, 2, 2, 1, -2, -3],
+            ],
         ];
     }
 
     /**
      * @param \Iterator $input
-     * @param callable  $streamFactoryFunc
-     * @param array     $expected
+     * @param callable $streamFactoryFunc
+     * @param array $expected
      * @return void
      * @dataProvider dataProviderForIterator
      */
@@ -1215,13 +1257,34 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(fn ($value, $key) => $key, fn ($value) => $value),
                 [0 => 1, '1' => 2, 2 => 3, '3' => 4, 4 => 5, 'a' => 11, 'b' => 22],
             ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toArray(),
+                [7, 5, 3, 3, 2, 2, 1, -2, -3],
+            ],
         ];
     }
 
     /**
      * @param \Traversable $input
-     * @param callable     $streamFactoryFunc
-     * @param array        $expected
+     * @param callable $streamFactoryFunc
+     * @param array $expected
      * @return void
      * @dataProvider dataProviderForTraversable
      */
@@ -1606,6 +1669,27 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(fn ($value, $key) => $key, fn ($value) => $value),
                 [0 => 1, '1' => 2, 2 => 3, '3' => 4, 4 => 5, 'a' => 11, 'b' => 22],
             ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toArray(),
+                [7, 5, 3, 3, 2, 2, 1, -2, -3],
+            ],
         ];
     }
 
@@ -1616,7 +1700,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
 
         // And
         $expected = ['pos' => [1, 2, 3], 'neg' => [-1, -2, -3]];
-        $result   = [];
+        $result = [];
 
         // When
         foreach (Stream::of($data)->groupBy(fn ($item) => $item > 0 ? 'pos' : 'neg') as $groupKey => $groupData) {
@@ -1634,13 +1718,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
 
         // And
         $expected = ['pos' => [1, 3], 'neg' => [-1, -3]];
-        $result   = [];
+        $result = [];
 
         // When
         foreach (
             Stream::of($data)
-                ->filterFalse(fn($value) => $value % 2 === 0)
-                ->groupBy(fn($item) => $item > 0 ? 'pos' : 'neg') as $groupKey => $groupData
+                ->filterFalse(fn ($value) => $value % 2 === 0)
+                ->groupBy(fn ($item) => $item > 0 ? 'pos' : 'neg') as $groupKey => $groupData
         ) {
             $result[$groupKey] = $groupData;
         }


### PR DESCRIPTION
Solving a specific problem, I ran into a situation where I need to find the maximum element according to some special rule — in this case, according to the value of the `getPriority()` method of the collection elements.

First I wrote this solution:

```php
$relatedEvents = [...]; // non-empty array

Stream::of($relatedEvents)
    ->filterFalse(fn ($elem) => $elem->getPriority() < 0)
    ->toValue(
        static function ($carry, $item) {
            return ($item->getPriority() >= ($carry ?? $item)->getPriority()) ? $item : $carry;
        }
    );
```

But I think we can simplify this code if we can give a specific comparator function to `toMax()` method as a parameter:

```php
Stream::of($relatedEvents)
    ->filterFalse(fn ($elem) => $elem->getPriority() < 0)
    ->toMax(fn => ($lhs, $rhs) => $lhs->getPriority() <=> $rhs->getPriority());
```

So I've implemented this functionality in this PR.

Summary:
1. Namespace `Reduce`: optional parameter `$comparator` added to methods `toMin()`, `toMax()`, `toMinMax()`.
2. Namespace `Stream`: optional parameter `$comparator` added to methods `toMin()`, `toMax()`, `toMinMax()`.
3. Test cases was added for these methods.
4. README and README-RU was updated with description of new parameter for these methods.
5. Backward compatibility is preserved.