### PR TITLE
Method `retro()` added to `Single` and `Stream` namespaces

### DIFF
--- a/src/Single.php
+++ b/src/Single.php
@@ -365,4 +365,51 @@ class Single
             yield $key => $func($datum);
         }
     }
+
+    /**
+     * Sorts the given iterable
+     *
+     * If comparator is null, the elements of given iterable must be comparable.
+     *
+     * @param iterable<mixed> $data
+     * @param callable|null $comparator (optional) function to determine how to sort elements if default sort is not appropriate.
+     *
+     * @return \Generator
+     */
+    public static function sort(iterable $data, callable $comparator = null): \Generator
+    {
+        $result = \iterator_to_array(IteratorFactory::makeIterator($data));
+
+        if ($comparator === null) {
+            \sort($result);
+        } else {
+            \usort($result, $comparator);
+        }
+
+        foreach ($result as $datum) {
+            yield $datum;
+        }
+    }
+
+    /**
+     * Reverse given iterable.
+     *
+     * @param iterable $data
+     *
+     * @return \Generator
+     */
+    public static function retro(iterable $data): \Generator
+    {
+        $keyStack = [];
+        $valueStack = [];
+
+        foreach ($data as $key => $datum) {
+            $keyStack[] = $key;
+            $valueStack[] = $datum;
+        }
+
+        while (count($keyStack)) {
+            yield array_pop($keyStack) => array_pop($valueStack);
+        }
+    }
 }

--- a/src/Single.php
+++ b/src/Single.php
@@ -394,7 +394,7 @@ class Single
     /**
      * Reverse given iterable.
      *
-     * @param iterable $data
+     * @param iterable<mixed> $data
      *
      * @return \Generator
      */

--- a/src/Single.php
+++ b/src/Single.php
@@ -398,7 +398,7 @@ class Single
      *
      * @return \Generator
      */
-    public static function retro(iterable $data): \Generator
+    public static function reverse(iterable $data): \Generator
     {
         $keyStack = [];
         $valueStack = [];

--- a/src/Single.php
+++ b/src/Single.php
@@ -367,31 +367,6 @@ class Single
     }
 
     /**
-     * Sorts the given iterable
-     *
-     * If comparator is null, the elements of given iterable must be comparable.
-     *
-     * @param iterable<mixed> $data
-     * @param callable|null $comparator (optional) function to determine how to sort elements if default sort is not appropriate.
-     *
-     * @return \Generator
-     */
-    public static function sort(iterable $data, callable $comparator = null): \Generator
-    {
-        $result = \iterator_to_array(IteratorFactory::makeIterator($data));
-
-        if ($comparator === null) {
-            \sort($result);
-        } else {
-            \usort($result, $comparator);
-        }
-
-        foreach ($result as $datum) {
-            yield $datum;
-        }
-    }
-
-    /**
      * Reverse given iterable.
      *
      * @param iterable<mixed> $data

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -465,6 +465,19 @@ class Stream implements \IteratorAggregate
     }
 
     /**
+     * Reverse the iterable source.
+     *
+     * @return $this
+     *
+     * @see Single::retro()
+     */
+    public function retro(): self
+    {
+        $this->iterable = Single::retro($this->iterable);
+        return $this;
+    }
+
+    /**
      * Chain iterable source withs given iterables together into a single iteration.
      *
      * Makes a single continuous sequence out of multiple sequences.

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -469,11 +469,11 @@ class Stream implements \IteratorAggregate
      *
      * @return $this
      *
-     * @see Single::retro()
+     * @see Single::reverse()
      */
-    public function retro(): self
+    public function reverse(): self
     {
-        $this->iterable = Single::retro($this->iterable);
+        $this->iterable = Single::reverse($this->iterable);
         return $this;
     }
 

--- a/tests/Single/RetroTest.php
+++ b/tests/Single/RetroTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IterTools\Tests\Single;
+
+use IterTools\Single;
+use IterTools\Tests\Fixture\GeneratorFixture;
+use IterTools\Tests\Fixture\IteratorAggregateFixture;
+
+class RetroTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider dataProviderForArray
+     * @param array $data
+     * @param array $expectedKeys
+     * @param array $expectedValues
+     */
+    public function testArray(array $data, array $expectedKeys, array $expectedValues): void
+    {
+        // Given
+        $resultKeys = [];
+        $resultValues = [];
+
+        // When
+        foreach (Single::retro($data) as $key => $value) {
+            $resultKeys[] = $key;
+            $resultValues[] = $value;
+        }
+
+        // Then
+        $this->assertEquals($expectedKeys, $resultKeys);
+        $this->assertEquals($expectedValues, $resultValues);
+    }
+
+    public function dataProviderForArray(): array
+    {
+        return [
+            [
+                [],
+                [],
+                [],
+            ],
+            [
+                [1],
+                [0],
+                [1],
+            ],
+            [
+                [1, 2, 3],
+                [2, 1, 0],
+                [3, 2, 1],
+            ],
+            [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['c', 'b', 'a'],
+                [3, 2, 1],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForGenerators
+     * @param \Generator $data
+     * @param array $expectedKeys
+     * @param array $expectedValues
+     */
+    public function testGenerators(\Generator $data, array $expectedKeys, array $expectedValues): void
+    {
+        // Given
+        $resultKeys = [];
+        $resultValues = [];
+
+        // When
+        foreach (Single::retro($data) as $key => $value) {
+            $resultKeys[] = $key;
+            $resultValues[] = $value;
+        }
+
+        // Then
+        $this->assertEquals($expectedKeys, $resultKeys);
+        $this->assertEquals($expectedValues, $resultValues);
+    }
+
+    public function dataProviderForGenerators(): array
+    {
+        $gen = fn ($data) => GeneratorFixture::getKeyValueGenerator($data);
+
+        return [
+            [
+                $gen([]),
+                [],
+                [],
+            ],
+            [
+                $gen([1]),
+                [0],
+                [1],
+            ],
+            [
+                $gen([1, 2, 3]),
+                [2, 1, 0],
+                [3, 2, 1],
+            ],
+            [
+                $gen(['a' => 1, 'b' => 2, 'c' => 3]),
+                ['c', 'b', 'a'],
+                [3, 2, 1],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIterators
+     * @param \Iterator $data
+     * @param array $expectedKeys
+     * @param array $expectedValues
+     */
+    public function testIterators(\Iterator $data, array $expectedKeys, array $expectedValues): void
+    {
+        // Given
+        $resultKeys = [];
+        $resultValues = [];
+
+        // When
+        foreach (Single::retro($data) as $key => $value) {
+            $resultKeys[] = $key;
+            $resultValues[] = $value;
+        }
+
+        // Then
+        $this->assertEquals($expectedKeys, $resultKeys);
+        $this->assertEquals($expectedValues, $resultValues);
+    }
+
+    public function dataProviderForIterators(): array
+    {
+        $iter = fn ($data) => new \ArrayIterator($data);
+
+        return [
+            [
+                $iter([]),
+                [],
+                [],
+            ],
+            [
+                $iter([1]),
+                [0],
+                [1],
+            ],
+            [
+                $iter([1, 2, 3]),
+                [2, 1, 0],
+                [3, 2, 1],
+            ],
+            [
+                $iter(['a' => 1, 'b' => 2, 'c' => 3]),
+                ['c', 'b', 'a'],
+                [3, 2, 1],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTraversables
+     * @param \Traversable $data
+     * @param array $expectedKeys
+     * @param array $expectedValues
+     */
+    public function testTraversables(\Traversable $data, array $expectedKeys, array $expectedValues): void
+    {
+        // Given
+        $resultKeys = [];
+        $resultValues = [];
+
+        // When
+        foreach (Single::retro($data) as $key => $value) {
+            $resultKeys[] = $key;
+            $resultValues[] = $value;
+        }
+
+        // Then
+        $this->assertEquals($expectedKeys, $resultKeys);
+        $this->assertEquals($expectedValues, $resultValues);
+    }
+
+    public function dataProviderForTraversables(): array
+    {
+        $trav = fn ($data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                $trav([]),
+                [],
+                [],
+            ],
+            [
+                $trav([1]),
+                [0],
+                [1],
+            ],
+            [
+                $trav([1, 2, 3]),
+                [2, 1, 0],
+                [3, 2, 1],
+            ],
+            [
+                $trav(['a' => 1, 'b' => 2, 'c' => 3]),
+                ['c', 'b', 'a'],
+                [3, 2, 1],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForComposite
+     * @param iterable $data
+     * @param array $expectedKeys
+     * @param array $expectedValues
+     */
+    public function testComposite(iterable $data, array $expectedKeys, array $expectedValues): void
+    {
+        // Given
+        $resultKeys = [];
+        $resultValues = [];
+
+        // When
+        foreach (Single::retro($data) as $key => $value) {
+            $resultKeys[] = $key;
+            $resultValues[] = $value;
+        }
+
+        // Then
+        $this->assertEquals($expectedKeys, $resultKeys);
+        $this->assertEquals($expectedValues, $resultValues);
+    }
+
+    public function dataProviderForComposite(): array
+    {
+        $composite = fn ($keys, $values) => GeneratorFixture::getCombined($keys, $values);
+
+        return [
+            [
+                $composite(
+                    [[1], [2], [3]],
+                    [['a'], ['b'], ['c']],
+                ),
+                [[3], [2], [1]],
+                [['c'], ['b'], ['a']],
+            ],
+            [
+                $composite(
+                    [[1], [1], [1]],
+                    [['a'], ['b'], ['c']],
+                ),
+                [[1], [1], [1]],
+                [['c'], ['b'], ['a']],
+            ],
+            [
+                $composite(
+                    [1, 1.1, 'abc', true, false, null, [1, 2, 3], $o1 = (object)[2, 3, 4]],
+                    [11, 11.1, 'bcd', false, true, null, [11, 22, 33], $o2 = (object)[22, 33, 44]],
+                ),
+                [$o1, [1, 2, 3], null, false, true, 'abc', 1.1, 1],
+                [$o2, [11, 22, 33], null, true, false, 'bcd', 11.1, 11],
+            ],
+        ];
+    }
+}

--- a/tests/Single/ReverseTest.php
+++ b/tests/Single/ReverseTest.php
@@ -8,7 +8,7 @@ use IterTools\Single;
 use IterTools\Tests\Fixture\GeneratorFixture;
 use IterTools\Tests\Fixture\IteratorAggregateFixture;
 
-class RetroTest extends \PHPUnit\Framework\TestCase
+class ReverseTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider dataProviderForArray
@@ -23,7 +23,7 @@ class RetroTest extends \PHPUnit\Framework\TestCase
         $resultValues = [];
 
         // When
-        foreach (Single::retro($data) as $key => $value) {
+        foreach (Single::reverse($data) as $key => $value) {
             $resultKeys[] = $key;
             $resultValues[] = $value;
         }
@@ -72,7 +72,7 @@ class RetroTest extends \PHPUnit\Framework\TestCase
         $resultValues = [];
 
         // When
-        foreach (Single::retro($data) as $key => $value) {
+        foreach (Single::reverse($data) as $key => $value) {
             $resultKeys[] = $key;
             $resultValues[] = $value;
         }
@@ -123,7 +123,7 @@ class RetroTest extends \PHPUnit\Framework\TestCase
         $resultValues = [];
 
         // When
-        foreach (Single::retro($data) as $key => $value) {
+        foreach (Single::reverse($data) as $key => $value) {
             $resultKeys[] = $key;
             $resultValues[] = $value;
         }
@@ -174,7 +174,7 @@ class RetroTest extends \PHPUnit\Framework\TestCase
         $resultValues = [];
 
         // When
-        foreach (Single::retro($data) as $key => $value) {
+        foreach (Single::reverse($data) as $key => $value) {
             $resultKeys[] = $key;
             $resultValues[] = $value;
         }
@@ -225,7 +225,7 @@ class RetroTest extends \PHPUnit\Framework\TestCase
         $resultValues = [];
 
         // When
-        foreach (Single::retro($data) as $key => $value) {
+        foreach (Single::reverse($data) as $key => $value) {
             $resultKeys[] = $key;
             $resultValues[] = $value;
         }

--- a/tests/Stream/SingleTest.php
+++ b/tests/Stream/SingleTest.php
@@ -573,6 +573,43 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(fn ($value, $key) => $key, fn ($value) => $value),
                 [0 => 1, '1' => 2, 2 => 3, '3' => 4, 4 => 5, 'a' => 11, 'b' => 22],
             ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                [2, 3, 1, 2, -3, -2, 5, 7, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toArray(),
+                [7, 5, 3, 3, 2, 2, 1, -2, -3],
+            ],
+            [
+                [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($value) => $value > 0)
+                    ->retro()
+                    ->toArray(),
+                [5, 4, 3, 2, 1],
+            ],
+            [
+                [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($value) => $value > 0)
+                    ->retro()
+                    ->toAssociativeArray(),
+                [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
+            ],
         ];
     }
 
@@ -1052,6 +1089,43 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(fn ($value, $key) => $key, fn ($value) => $value),
                 [0 => 1, '1' => 2, 2 => 3, '3' => 4, 4 => 5, 'a' => 11, 'b' => 22],
             ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $gen([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toArray(),
+                [7, 5, 3, 3, 2, 2, 1, -2, -3],
+            ],
+            [
+                $gen([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($value) => $value > 0)
+                    ->retro()
+                    ->toArray(),
+                [5, 4, 3, 2, 1],
+            ],
+            [
+                $gen([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($value) => $value > 0)
+                    ->retro()
+                    ->toAssociativeArray(),
+                [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
+            ],
         ];
     }
 
@@ -1523,6 +1597,43 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(fn ($value, $key) => $key, fn ($value) => $value),
                 [0 => 1, '1' => 2, 2 => 3, '3' => 4, 4 => 5, 'a' => 11, 'b' => 22],
             ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $iter([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toArray(),
+                [7, 5, 3, 3, 2, 2, 1, -2, -3],
+            ],
+            [
+                $iter([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($value) => $value > 0)
+                    ->retro()
+                    ->toArray(),
+                [5, 4, 3, 2, 1],
+            ],
+            [
+                $iter([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($value) => $value > 0)
+                    ->retro()
+                    ->toAssociativeArray(),
+                [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
+            ],
         ];
     }
 
@@ -1993,6 +2104,43 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->compressAssociative([0, '1', 2, '3', 4, 'a', 10, 'b', 12, 'd', 14])
                     ->toAssociativeArray(fn ($value, $key) => $key, fn ($value) => $value),
                 [0 => 1, '1' => 2, 2 => 3, '3' => 4, 4 => 5, 'a' => 11, 'b' => 22],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort()
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $lhs <=> $rhs)
+                    ->toArray(),
+                [-3, -2, 1, 2, 2, 3, 3, 5, 7],
+            ],
+            [
+                $trav([2, 3, 1, 2, -3, -2, 5, 7, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->sort(fn ($lhs, $rhs) => $rhs <=> $lhs)
+                    ->toArray(),
+                [7, 5, 3, 3, 2, 2, 1, -2, -3],
+            ],
+            [
+                $trav([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($value) => $value > 0)
+                    ->retro()
+                    ->toArray(),
+                [5, 4, 3, 2, 1],
+            ],
+            [
+                $trav([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->filterTrue(fn ($value) => $value > 0)
+                    ->retro()
+                    ->toAssociativeArray(),
+                [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
             ],
         ];
     }

--- a/tests/Stream/SingleTest.php
+++ b/tests/Stream/SingleTest.php
@@ -598,7 +598,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                 [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($value) => $value > 0)
-                    ->retro()
+                    ->reverse()
                     ->toArray(),
                 [5, 4, 3, 2, 1],
             ],
@@ -606,7 +606,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                 [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($value) => $value > 0)
-                    ->retro()
+                    ->reverse()
                     ->toAssociativeArray(),
                 [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
             ],
@@ -1114,7 +1114,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                 $gen([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($value) => $value > 0)
-                    ->retro()
+                    ->reverse()
                     ->toArray(),
                 [5, 4, 3, 2, 1],
             ],
@@ -1122,7 +1122,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                 $gen([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($value) => $value > 0)
-                    ->retro()
+                    ->reverse()
                     ->toAssociativeArray(),
                 [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
             ],
@@ -1622,7 +1622,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                 $iter([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($value) => $value > 0)
-                    ->retro()
+                    ->reverse()
                     ->toArray(),
                 [5, 4, 3, 2, 1],
             ],
@@ -1630,7 +1630,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                 $iter([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($value) => $value > 0)
-                    ->retro()
+                    ->reverse()
                     ->toAssociativeArray(),
                 [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
             ],
@@ -2130,7 +2130,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                 $trav([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($value) => $value > 0)
-                    ->retro()
+                    ->reverse()
                     ->toArray(),
                 [5, 4, 3, 2, 1],
             ],
@@ -2138,7 +2138,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                 $trav([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
                 fn (iterable $iterable) => Stream::of($iterable)
                     ->filterTrue(fn ($value) => $value > 0)
-                    ->retro()
+                    ->reverse()
                     ->toAssociativeArray(),
                 [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
             ],

--- a/tests/Stream/SingleTest.php
+++ b/tests/Stream/SingleTest.php
@@ -608,7 +608,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->filterTrue(fn ($value) => $value > 0)
                     ->reverse()
                     ->toAssociativeArray(),
-                [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
+                [10 => 5, 9 => 4, 8 => 3, 7 => 2, 6 => 1],
             ],
         ];
     }
@@ -1124,7 +1124,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->filterTrue(fn ($value) => $value > 0)
                     ->reverse()
                     ->toAssociativeArray(),
-                [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
+                [10 => 5, 9 => 4, 8 => 3, 7 => 2, 6 => 1],
             ],
         ];
     }
@@ -1632,7 +1632,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->filterTrue(fn ($value) => $value > 0)
                     ->reverse()
                     ->toAssociativeArray(),
-                [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
+                [10 => 5, 9 => 4, 8 => 3, 7 => 2, 6 => 1],
             ],
         ];
     }
@@ -2140,7 +2140,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->filterTrue(fn ($value) => $value > 0)
                     ->reverse()
                     ->toAssociativeArray(),
-                [4 => 5, 3 => 4, 2 => 3, 1 => 2, 0 => 1],
+                [10 => 5, 9 => 4, 8 => 3, 7 => 2, 6 => 1],
             ],
         ];
     }


### PR DESCRIPTION
Hi @markrogoyski,

I've added methods for reversing iterables.

Summary:
* `Single::retro()` method was added and tested;
* `Stream::retro()` method was added and tested.