### PR TITLE
Method `Single::breed()` added

### DIFF
--- a/src/Single.php
+++ b/src/Single.php
@@ -387,4 +387,21 @@ class Single
             yield \array_pop($keyStack) => \array_pop($valueStack);
         }
     }
+
+    /**
+     * Breeds items of given collection using producing function.
+     *
+     * @param iterable<mixed> $data
+     * @param callable $breeder
+     *
+     * @return \Generator
+     */
+    public static function breed(iterable $data, callable $breeder): \Generator
+    {
+        foreach ($data as $datum) {
+            foreach ($breeder($datum) as $product) {
+                yield $product;
+            }
+        }
+    }
 }

--- a/src/Single.php
+++ b/src/Single.php
@@ -367,6 +367,24 @@ class Single
     }
 
     /**
+     * Returns a new collection formed by applying a given callback function to each element
+     * of the given collection, and then flattening the result by one level.
+     *
+     * @param iterable<mixed> $data
+     * @param callable $func
+     *
+     * @return \Generator
+     */
+    public static function flatMap(iterable $data, callable $func): \Generator
+    {
+        foreach ($data as $datum) {
+            foreach ($func($datum, $func) as $product) {
+                yield $product;
+            }
+        }
+    }
+
+    /**
      * Reverse given iterable.
      *
      * @param iterable<mixed> $data
@@ -385,23 +403,6 @@ class Single
 
         while (\count($keyStack) > 0) {
             yield \array_pop($keyStack) => \array_pop($valueStack);
-        }
-    }
-
-    /**
-     * Breeds items of given collection using producing function.
-     *
-     * @param iterable<mixed> $data
-     * @param callable $breeder
-     *
-     * @return \Generator
-     */
-    public static function breed(iterable $data, callable $breeder): \Generator
-    {
-        foreach ($data as $datum) {
-            foreach ($breeder($datum, $breeder) as $product) {
-                yield $product;
-            }
         }
     }
 }

--- a/src/Single.php
+++ b/src/Single.php
@@ -399,7 +399,7 @@ class Single
     public static function breed(iterable $data, callable $breeder): \Generator
     {
         foreach ($data as $datum) {
-            foreach ($breeder($datum) as $product) {
+            foreach ($breeder($datum, $breeder) as $product) {
                 yield $product;
             }
         }

--- a/src/Single.php
+++ b/src/Single.php
@@ -378,8 +378,13 @@ class Single
     public static function flatMap(iterable $data, callable $func): \Generator
     {
         foreach ($data as $datum) {
-            foreach ($func($datum, $func) as $product) {
-                yield $product;
+            $unflattened = $func($datum, $func);
+            if (is_iterable($unflattened)) {
+                foreach ($func($datum, $func) as $unflattenedItem) {
+                    yield $unflattenedItem;
+                }
+            } else {
+                yield $unflattened;
             }
         }
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -431,6 +431,22 @@ class Stream implements \IteratorAggregate
     }
 
     /**
+     * Returns a new collection formed by applying a given callback function
+     * to each element of the stream, and then flattening the result by one level.
+     *
+     * @param callable $func
+     *
+     * @return $this
+     *
+     * @see Single::flatMap()
+     */
+    public function flatMap(callable $func): self
+    {
+        $this->iterable = Single::flatMap($this->iterable, $func);
+        return $this;
+    }
+
+    /**
      * Sorts the stream.
      *
      * If comparator is null, then elements of the iterable source must be comparable.
@@ -474,21 +490,6 @@ class Stream implements \IteratorAggregate
     public function reverse(): self
     {
         $this->iterable = Single::reverse($this->iterable);
-        return $this;
-    }
-
-    /**
-     * Breeds items of the stream using producing function.
-     *
-     * @param callable $breeder
-     *
-     * @return $this
-     *
-     * @see Single::breed()
-     */
-    public function breed(callable $breeder): self
-    {
-        $this->iterable = Single::breed($this->iterable, $breeder);
         return $this;
     }
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -478,6 +478,21 @@ class Stream implements \IteratorAggregate
     }
 
     /**
+     * Breeds items of the stream using producing function.
+     *
+     * @param callable $breeder
+     *
+     * @return $this
+     *
+     * @see Single::breed()
+     */
+    public function breed(callable $breeder): self
+    {
+        $this->iterable = Single::breed($this->iterable, $breeder);
+        return $this;
+    }
+
+    /**
      * Chain iterable source withs given iterables together into a single iteration.
      *
      * Makes a single continuous sequence out of multiple sequences.

--- a/tests/Single/BreedTest.php
+++ b/tests/Single/BreedTest.php
@@ -1,0 +1,423 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IterTools\Tests\Single;
+
+use IterTools\Single;
+use IterTools\Tests\Fixture\ArrayIteratorFixture;
+use IterTools\Tests\Fixture\GeneratorFixture;
+use IterTools\Tests\Fixture\IteratorAggregateFixture;
+
+class BreedTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider dataProviderForArray
+     * @param array $iterable
+     * @param callable $breeder
+     * @param array $expected
+     */
+    public function testArray(array $iterable, callable $breeder, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Single::breed($iterable, $breeder) as $item) {
+            $result[] = $item;
+        }
+
+        // Then
+        $this->assertEquals($expected, $result);
+    }
+
+    public function dataProviderForArray(): array
+    {
+        return [
+            [
+                [],
+                fn ($item) => [$item],
+                [],
+            ],
+            [
+                [0],
+                fn ($item) => [$item],
+                [0],
+            ],
+            [
+                [1],
+                fn ($item) => [$item],
+                [1],
+            ],
+            [
+                [2],
+                fn ($item) => [$item],
+                [2],
+            ],
+            [
+                [0, 1, 2, 3, 4, 5],
+                fn ($item) => [$item],
+                [0, 1, 2, 3, 4, 5],
+            ],
+            [
+                [2],
+                fn ($item) => [$item, $item],
+                [2, 2],
+            ],
+            [
+                [0, 1, 2, 3, 4, 5],
+                fn ($item) => [$item, $item],
+                [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+            ],
+            [
+                [0, 1, 2, 3, 4, 5],
+                fn ($item) => [$item, -$item],
+                [0, 0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5],
+            ],
+            [
+                [],
+                fn ($item) => Single::repeat($item, $item),
+                [],
+            ],
+            [
+                [0],
+                fn ($item) => Single::repeat($item, $item),
+                [],
+            ],
+            [
+                [1],
+                fn ($item) => Single::repeat($item, $item),
+                [1],
+            ],
+            [
+                [2],
+                fn ($item) => Single::repeat($item, $item),
+                [2, 2],
+            ],
+            [
+                [0, 1, 2, 3, 4, 5],
+                fn ($item) => Single::repeat($item, $item),
+                [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5],
+            ],
+            [
+                [
+                    ['name' => 'bird', 'eggs' => 2],
+                    ['name' => 'lizard', 'eggs' => 3],
+                    ['name' => 'echidna', 'eggs' => 1],
+                    ['name' => 'tyrannosaur', 'eggs' => 0],
+                ],
+                fn ($animal) => Single::repeat($animal['name'], $animal['eggs']),
+                ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForGenerators
+     * @param \Generator $iterable
+     * @param callable $breeder
+     * @param array $expected
+     */
+    public function testGenerators(\Generator $iterable, callable $breeder, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Single::breed($iterable, $breeder) as $item) {
+            $result[] = $item;
+        }
+
+        // Then
+        $this->assertEquals($expected, $result);
+    }
+
+    public function dataProviderForGenerators(): array
+    {
+        $gen = fn ($data) => GeneratorFixture::getGenerator($data);
+
+        return [
+            [
+                $gen([]),
+                fn ($item) => [$item],
+                [],
+            ],
+            [
+                $gen([0]),
+                fn ($item) => [$item],
+                [0],
+            ],
+            [
+                $gen([1]),
+                fn ($item) => [$item],
+                [1],
+            ],
+            [
+                $gen([2]),
+                fn ($item) => [$item],
+                [2],
+            ],
+            [
+                $gen([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item],
+                [0, 1, 2, 3, 4, 5],
+            ],
+            [
+                $gen([2]),
+                fn ($item) => [$item, $item],
+                [2, 2],
+            ],
+            [
+                $gen([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item, $item],
+                [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+            ],
+            [
+                $gen([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item, -$item],
+                [0, 0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5],
+            ],
+            [
+                $gen([]),
+                fn ($item) => Single::repeat($item, $item),
+                [],
+            ],
+            [
+                $gen([0]),
+                fn ($item) => Single::repeat($item, $item),
+                [],
+            ],
+            [
+                $gen([1]),
+                fn ($item) => Single::repeat($item, $item),
+                [1],
+            ],
+            [
+                $gen([2]),
+                fn ($item) => Single::repeat($item, $item),
+                [2, 2],
+            ],
+            [
+                $gen([0, 1, 2, 3, 4, 5]),
+                fn ($item) => Single::repeat($item, $item),
+                [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5],
+            ],
+            [
+                $gen([
+                    ['name' => 'bird', 'eggs' => 2],
+                    ['name' => 'lizard', 'eggs' => 3],
+                    ['name' => 'echidna', 'eggs' => 1],
+                    ['name' => 'tyrannosaur', 'eggs' => 0],
+                ]),
+                fn ($animal) => Single::repeat($animal['name'], $animal['eggs']),
+                ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIterators
+     * @param \Iterator $iterable
+     * @param callable $breeder
+     * @param array $expected
+     */
+    public function testIterators(\Iterator $iterable, callable $breeder, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Single::breed($iterable, $breeder) as $item) {
+            $result[] = $item;
+        }
+
+        // Then
+        $this->assertEquals($expected, $result);
+    }
+
+    public function dataProviderForIterators(): array
+    {
+        $iter = fn ($data) => new ArrayIteratorFixture($data);
+
+        return [
+            [
+                $iter([]),
+                fn ($item) => [$item],
+                [],
+            ],
+            [
+                $iter([0]),
+                fn ($item) => [$item],
+                [0],
+            ],
+            [
+                $iter([1]),
+                fn ($item) => [$item],
+                [1],
+            ],
+            [
+                $iter([2]),
+                fn ($item) => [$item],
+                [2],
+            ],
+            [
+                $iter([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item],
+                [0, 1, 2, 3, 4, 5],
+            ],
+            [
+                $iter([2]),
+                fn ($item) => [$item, $item],
+                [2, 2],
+            ],
+            [
+                $iter([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item, $item],
+                [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+            ],
+            [
+                $iter([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item, -$item],
+                [0, 0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5],
+            ],
+            [
+                $iter([]),
+                fn ($item) => Single::repeat($item, $item),
+                [],
+            ],
+            [
+                $iter([0]),
+                fn ($item) => Single::repeat($item, $item),
+                [],
+            ],
+            [
+                $iter([1]),
+                fn ($item) => Single::repeat($item, $item),
+                [1],
+            ],
+            [
+                $iter([2]),
+                fn ($item) => Single::repeat($item, $item),
+                [2, 2],
+            ],
+            [
+                $iter([0, 1, 2, 3, 4, 5]),
+                fn ($item) => Single::repeat($item, $item),
+                [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5],
+            ],
+            [
+                $iter([
+                    ['name' => 'bird', 'eggs' => 2],
+                    ['name' => 'lizard', 'eggs' => 3],
+                    ['name' => 'echidna', 'eggs' => 1],
+                    ['name' => 'tyrannosaur', 'eggs' => 0],
+                ]),
+                fn ($animal) => Single::repeat($animal['name'], $animal['eggs']),
+                ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTraversables
+     * @param \Traversable $iterable
+     * @param callable $breeder
+     * @param array $expected
+     */
+    public function testTraversables(\Traversable $iterable, callable $breeder, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Single::breed($iterable, $breeder) as $item) {
+            $result[] = $item;
+        }
+
+        // Then
+        $this->assertEquals($expected, $result);
+    }
+
+    public function dataProviderForTraversables(): array
+    {
+        $trav = fn ($data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                $trav([]),
+                fn ($item) => [$item],
+                [],
+            ],
+            [
+                $trav([0]),
+                fn ($item) => [$item],
+                [0],
+            ],
+            [
+                $trav([1]),
+                fn ($item) => [$item],
+                [1],
+            ],
+            [
+                $trav([2]),
+                fn ($item) => [$item],
+                [2],
+            ],
+            [
+                $trav([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item],
+                [0, 1, 2, 3, 4, 5],
+            ],
+            [
+                $trav([2]),
+                fn ($item) => [$item, $item],
+                [2, 2],
+            ],
+            [
+                $trav([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item, $item],
+                [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+            ],
+            [
+                $trav([0, 1, 2, 3, 4, 5]),
+                fn ($item) => [$item, -$item],
+                [0, 0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5],
+            ],
+            [
+                $trav([]),
+                fn ($item) => Single::repeat($item, $item),
+                [],
+            ],
+            [
+                $trav([0]),
+                fn ($item) => Single::repeat($item, $item),
+                [],
+            ],
+            [
+                $trav([1]),
+                fn ($item) => Single::repeat($item, $item),
+                [1],
+            ],
+            [
+                $trav([2]),
+                fn ($item) => Single::repeat($item, $item),
+                [2, 2],
+            ],
+            [
+                $trav([0, 1, 2, 3, 4, 5]),
+                fn ($item) => Single::repeat($item, $item),
+                [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5],
+            ],
+            [
+                $trav([
+                    ['name' => 'bird', 'eggs' => 2],
+                    ['name' => 'lizard', 'eggs' => 3],
+                    ['name' => 'echidna', 'eggs' => 1],
+                    ['name' => 'tyrannosaur', 'eggs' => 0],
+                ]),
+                fn ($animal) => Single::repeat($animal['name'], $animal['eggs']),
+                ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna'],
+            ],
+        ];
+    }
+}

--- a/tests/Single/BreedTest.php
+++ b/tests/Single/BreedTest.php
@@ -109,6 +109,13 @@ class BreedTest extends \PHPUnit\Framework\TestCase
                 fn ($animal) => Single::repeat($animal['name'], $animal['eggs']),
                 ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna'],
             ],
+            [
+                [[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10],
+                fn ($item, $breeder) => is_iterable($item)
+                    ? Single::breed($item, $breeder)
+                    : [$item],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            ],
         ];
     }
 
@@ -211,6 +218,13 @@ class BreedTest extends \PHPUnit\Framework\TestCase
                 ]),
                 fn ($animal) => Single::repeat($animal['name'], $animal['eggs']),
                 ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna'],
+            ],
+            [
+                $gen([[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10]),
+                fn ($item, $breeder) => is_iterable($item)
+                    ? Single::breed($item, $breeder)
+                    : [$item],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             ],
         ];
     }
@@ -315,6 +329,13 @@ class BreedTest extends \PHPUnit\Framework\TestCase
                 fn ($animal) => Single::repeat($animal['name'], $animal['eggs']),
                 ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna'],
             ],
+            [
+                $iter([[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10]),
+                fn ($item, $breeder) => is_iterable($item)
+                    ? Single::breed($item, $breeder)
+                    : [$item],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            ],
         ];
     }
 
@@ -417,6 +438,13 @@ class BreedTest extends \PHPUnit\Framework\TestCase
                 ]),
                 fn ($animal) => Single::repeat($animal['name'], $animal['eggs']),
                 ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna'],
+            ],
+            [
+                $trav([[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10]),
+                fn ($item, $breeder) => is_iterable($item)
+                    ? Single::breed($item, $breeder)
+                    : [$item],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             ],
         ];
     }

--- a/tests/Single/FlatMapTest.php
+++ b/tests/Single/FlatMapTest.php
@@ -9,21 +9,21 @@ use IterTools\Tests\Fixture\ArrayIteratorFixture;
 use IterTools\Tests\Fixture\GeneratorFixture;
 use IterTools\Tests\Fixture\IteratorAggregateFixture;
 
-class BreedTest extends \PHPUnit\Framework\TestCase
+class FlatMapTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider dataProviderForArray
      * @param array $iterable
-     * @param callable $breeder
+     * @param callable $func
      * @param array $expected
      */
-    public function testArray(array $iterable, callable $breeder, array $expected): void
+    public function testArray(array $iterable, callable $func, array $expected): void
     {
         // Given
         $result = [];
 
         // When
-        foreach (Single::breed($iterable, $breeder) as $item) {
+        foreach (Single::flatMap($iterable, $func) as $item) {
             $result[] = $item;
         }
 
@@ -111,8 +111,8 @@ class BreedTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 [[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10],
-                fn ($item, $breeder) => is_iterable($item)
-                    ? Single::breed($item, $breeder)
+                fn ($item, $func) => is_iterable($item)
+                    ? Single::flatMap($item, $func)
                     : [$item],
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             ],
@@ -122,16 +122,16 @@ class BreedTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dataProviderForGenerators
      * @param \Generator $iterable
-     * @param callable $breeder
+     * @param callable $func
      * @param array $expected
      */
-    public function testGenerators(\Generator $iterable, callable $breeder, array $expected): void
+    public function testGenerators(\Generator $iterable, callable $func, array $expected): void
     {
         // Given
         $result = [];
 
         // When
-        foreach (Single::breed($iterable, $breeder) as $item) {
+        foreach (Single::flatMap($iterable, $func) as $item) {
             $result[] = $item;
         }
 
@@ -221,8 +221,8 @@ class BreedTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $gen([[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10]),
-                fn ($item, $breeder) => is_iterable($item)
-                    ? Single::breed($item, $breeder)
+                fn ($item, $func) => is_iterable($item)
+                    ? Single::flatMap($item, $func)
                     : [$item],
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             ],
@@ -232,16 +232,16 @@ class BreedTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dataProviderForIterators
      * @param \Iterator $iterable
-     * @param callable $breeder
+     * @param callable $func
      * @param array $expected
      */
-    public function testIterators(\Iterator $iterable, callable $breeder, array $expected): void
+    public function testIterators(\Iterator $iterable, callable $func, array $expected): void
     {
         // Given
         $result = [];
 
         // When
-        foreach (Single::breed($iterable, $breeder) as $item) {
+        foreach (Single::flatMap($iterable, $func) as $item) {
             $result[] = $item;
         }
 
@@ -331,8 +331,8 @@ class BreedTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $iter([[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10]),
-                fn ($item, $breeder) => is_iterable($item)
-                    ? Single::breed($item, $breeder)
+                fn ($item, $func) => is_iterable($item)
+                    ? Single::flatMap($item, $func)
                     : [$item],
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             ],
@@ -342,16 +342,16 @@ class BreedTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dataProviderForTraversables
      * @param \Traversable $iterable
-     * @param callable $breeder
+     * @param callable $func
      * @param array $expected
      */
-    public function testTraversables(\Traversable $iterable, callable $breeder, array $expected): void
+    public function testTraversables(\Traversable $iterable, callable $func, array $expected): void
     {
         // Given
         $result = [];
 
         // When
-        foreach (Single::breed($iterable, $breeder) as $item) {
+        foreach (Single::flatMap($iterable, $func) as $item) {
             $result[] = $item;
         }
 
@@ -441,8 +441,8 @@ class BreedTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 $trav([[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10]),
-                fn ($item, $breeder) => is_iterable($item)
-                    ? Single::breed($item, $breeder)
+                fn ($item, $func) => is_iterable($item)
+                    ? Single::flatMap($item, $func)
                     : [$item],
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             ],

--- a/tests/Stream/SingleTest.php
+++ b/tests/Stream/SingleTest.php
@@ -618,6 +618,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toArray(),
                 [1, 1, 2, 2, 2, 3, 3, 3, 3],
             ],
+            [
+                [1, 2, [3, 4], [5, 6], 7, 8],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->flatMap(fn ($item) => $item)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7, 8],
+            ],
         ];
     }
 
@@ -1141,6 +1148,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toArray(),
                 [1, 1, 2, 2, 2, 3, 3, 3, 3],
             ],
+            [
+                $gen([1, 2, [3, 4], [5, 6], 7, 8]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->flatMap(fn ($item) => $item)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7, 8],
+            ],
         ];
     }
 
@@ -1656,6 +1670,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toArray(),
                 [1, 1, 2, 2, 2, 3, 3, 3, 3],
             ],
+            [
+                $iter([1, 2, [3, 4], [5, 6], 7, 8]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->flatMap(fn ($item) => $item)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7, 8],
+            ],
         ];
     }
 
@@ -2170,6 +2191,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->flatMap(fn ($item) => Single::repeat($item, $item + 1))
                     ->toArray(),
                 [1, 1, 2, 2, 2, 3, 3, 3, 3],
+            ],
+            [
+                $trav([1, 2, [3, 4], [5, 6], 7, 8]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->flatMap(fn ($item) => $item)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7, 8],
             ],
         ];
     }

--- a/tests/Stream/SingleTest.php
+++ b/tests/Stream/SingleTest.php
@@ -614,7 +614,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
             [
                 [1, 2, 3],
                 fn (iterable $iterable) => Stream::of($iterable)
-                    ->breed(fn ($item) => Single::repeat($item, $item + 1))
+                    ->flatMap(fn ($item) => Single::repeat($item, $item + 1))
                     ->toArray(),
                 [1, 1, 2, 2, 2, 3, 3, 3, 3],
             ],
@@ -1137,7 +1137,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
             [
                 $gen([1, 2, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
-                    ->breed(fn ($item) => Single::repeat($item, $item + 1))
+                    ->flatMap(fn ($item) => Single::repeat($item, $item + 1))
                     ->toArray(),
                 [1, 1, 2, 2, 2, 3, 3, 3, 3],
             ],
@@ -1652,7 +1652,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
             [
                 $iter([1, 2, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
-                    ->breed(fn ($item) => Single::repeat($item, $item + 1))
+                    ->flatMap(fn ($item) => Single::repeat($item, $item + 1))
                     ->toArray(),
                 [1, 1, 2, 2, 2, 3, 3, 3, 3],
             ],
@@ -2167,7 +2167,7 @@ class SingleTest extends \PHPUnit\Framework\TestCase
             [
                 $trav([1, 2, 3]),
                 fn (iterable $iterable) => Stream::of($iterable)
-                    ->breed(fn ($item) => Single::repeat($item, $item + 1))
+                    ->flatMap(fn ($item) => Single::repeat($item, $item + 1))
                     ->toArray(),
                 [1, 1, 2, 2, 2, 3, 3, 3, 3],
             ],

--- a/tests/Stream/SingleTest.php
+++ b/tests/Stream/SingleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace IterTools\Tests\Stream;
 
+use IterTools\Single;
 use IterTools\Stream;
 use IterTools\Tests\Fixture\ArrayIteratorFixture;
 use IterTools\Tests\Fixture\GeneratorFixture;
@@ -610,6 +611,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(),
                 [10 => 5, 9 => 4, 8 => 3, 7 => 2, 6 => 1],
             ],
+            [
+                [1, 2, 3],
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->breed(fn ($item) => Single::repeat($item, $item + 1))
+                    ->toArray(),
+                [1, 1, 2, 2, 2, 3, 3, 3, 3],
+            ],
         ];
     }
 
@@ -1126,6 +1134,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(),
                 [10 => 5, 9 => 4, 8 => 3, 7 => 2, 6 => 1],
             ],
+            [
+                $gen([1, 2, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->breed(fn ($item) => Single::repeat($item, $item + 1))
+                    ->toArray(),
+                [1, 1, 2, 2, 2, 3, 3, 3, 3],
+            ],
         ];
     }
 
@@ -1634,6 +1649,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->toAssociativeArray(),
                 [10 => 5, 9 => 4, 8 => 3, 7 => 2, 6 => 1],
             ],
+            [
+                $iter([1, 2, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->breed(fn ($item) => Single::repeat($item, $item + 1))
+                    ->toArray(),
+                [1, 1, 2, 2, 2, 3, 3, 3, 3],
+            ],
         ];
     }
 
@@ -2141,6 +2163,13 @@ class SingleTest extends \PHPUnit\Framework\TestCase
                     ->reverse()
                     ->toAssociativeArray(),
                 [10 => 5, 9 => 4, 8 => 3, 7 => 2, 6 => 1],
+            ],
+            [
+                $trav([1, 2, 3]),
+                fn (iterable $iterable) => Stream::of($iterable)
+                    ->breed(fn ($item) => Single::repeat($item, $item + 1))
+                    ->toArray(),
+                [1, 1, 2, 2, 2, 3, 3, 3, 3],
             ],
         ];
     }


### PR DESCRIPTION
Hi @markrogoyski,

Methods `Single::breed()`, `Stream::breed()` added and covered with tests.

I'm not sure about the naming, maybe you can come up with a better name.

Here are examples that explain the meaning of this functionality:

```php
$numbers = [1, 2, 3];

$result = Single::breed($numbers, fn ($number) => [$number, -$number]);
// [1, -1, 2, -2, 3, -3];
```

```php
$animals = [
    ['name' => 'bird', 'eggs' => 2],
    ['name' => 'lizard', 'eggs' => 3],
    ['name' => 'echidna', 'eggs' => 1],
    ['name' => 'tyrannosaur', 'eggs' => 0],
];

$nextPopulation = Single::breed($animals, fn ($animal) => Single::repeat($animal['name'], $animal['eggs']));
// ['bird', 'bird', 'lizard', 'lizard', 'lizard', 'echidna']
```

```php
$input = [[1, 2, [3, [4, 5]], 6], [7], [8, 9], 10];

$result = Single::breed(
    $input,
    fn ($item, $breeder) => is_iterable($item)
        ? Single::breed($item, $breeder)
        : [$item]
);
$result = iterator_to_array($result);
$this->assertEquals([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], $result);
```