### PR TITLE
`Set::union()` method added

### DIFF
--- a/src/Set.php
+++ b/src/Set.php
@@ -125,6 +125,45 @@ class Set
     }
 
     /**
+     * Iterates union of given iterables in strict type mode.
+     *
+     * If input iterables produce duplicate items, then multiset intersection rules apply.
+     *
+     * Strict-type comparisons:
+     *  - scalars: compares strictly by type
+     *  - objects: always treats different instances as not equal to each other
+     *  - arrays: compares serialized
+     *
+     * @param iterable<mixed> ...$iterables
+     *
+     * @return \Generator
+     */
+    public static function union(iterable ...$iterables): \Generator
+    {
+        return static::partialIntersection(1, ...$iterables);
+    }
+
+
+    /**
+     * Iterates union of given iterables in strict type mode.
+     *
+     * If input iterables produce duplicate items, then multiset intersection rules apply.
+     *
+     * Coercive (non-strict) type comparisons:
+     *  - scalars: compares non-strictly by value
+     *  - objects: compares serialized
+     *  - arrays: compares serialized
+     *
+     * @param iterable<mixed> ...$iterables
+     *
+     * @return \Generator
+     */
+    public static function unionCoercive(iterable ...$iterables): \Generator
+    {
+        return static::partialIntersectionCoercive(1, ...$iterables);
+    }
+
+    /**
      * Iterates the symmetric difference of iterables in strict type mode.
      *
      * If input iterables produce duplicate items, then multiset difference rules apply.

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -876,6 +876,44 @@ class Stream implements \IteratorAggregate
         return $this;
     }
 
+    /**
+     * Iterates union of iterable source and given iterables in strict type mode.
+     *
+     *  - scalars: compares strictly by type;
+     *  - objects: always treats different instances as not equal to each other;
+     *  - arrays: compares serialized.
+     *
+     * @param array<iterable<mixed>> ...$iterables
+     *
+     * @return $this
+     *
+     * @see Set::union()
+     */
+    public function unionWith(iterable ...$iterables): self
+    {
+        $this->iterable = Set::union($this->iterable, ...$iterables);
+        return $this;
+    }
+
+    /**
+     * Iterates union of iterable source and given iterables in non-strict type mode.
+     *
+     *  - scalars: compares non-strictly by value;
+     *  - objects: compares serialized;
+     *  - arrays: compares serialized.
+     *
+     * @param array<iterable<mixed>> ...$iterables
+     *
+     * @return $this
+     *
+     * @see Set::unionCoercive()
+     */
+    public function unionCoerciveWith(iterable ...$iterables): self
+    {
+        $this->iterable = Set::unionCoercive($this->iterable, ...$iterables);
+        return $this;
+    }
+
     // STREAM DEBUG OPERATIONS
 
     /**

--- a/tests/Set/UnionCoerciveTest.php
+++ b/tests/Set/UnionCoerciveTest.php
@@ -9,7 +9,7 @@ use IterTools\Tests\Fixture\ArrayIteratorFixture;
 use IterTools\Tests\Fixture\GeneratorFixture;
 use IterTools\Tests\Fixture\IteratorAggregateFixture;
 
-class UnionTest extends \PHPUnit\Framework\TestCase
+class UnionCoerciveTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider dataProviderForArraySets
@@ -23,7 +23,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
         $result = [];
 
         // When
-        foreach (Set::union(...$iterables) as $datum) {
+        foreach (Set::unionCoercive(...$iterables) as $datum) {
             $result[] = $datum;
         }
 
@@ -59,7 +59,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 2],
             ],
             [
-                [[1, 2], [2, 3]],
+                [['1', '2'], [2, 3]],
                 [1, 2, 3],
             ],
             [
@@ -67,7 +67,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 2, 3, 4],
             ],
             [
-                [[1, 2], [3, 4], [4, 5]],
+                [[1, 2], [3, 4], ['4', 5]],
                 [1, 2, 3, 4, 5],
             ],
             [
@@ -79,7 +79,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     [1, 2.2, '3', true, null, [1], (object)[1]],
                     [1.0, 2.2, 3, false, INF, [1], (object)[2]],
                 ],
-                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+                [1, 2.2, '3', true, false, INF, [1], (object)[1], (object)[2]],
             ],
         ];
     }
@@ -92,31 +92,31 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 1],
             ],
             [
-                [[1], [1, 1]],
+                [[1], [1, '1']],
                 [1, 1],
             ],
             [
-                [[1, 1], [1, 1]],
+                [[1, '1'], [1, 1]],
                 [1, 1],
             ],
             [
-                [[1, 1, 1], [1, 1]],
+                [[1, 1, 1], ['1', 1]],
                 [1, 1, 1],
             ],
             [
-                [[1, 2], [1, 1]],
+                [[1, 2], ['1', 1]],
                 [1, 1, 2],
             ],
             [
-                [[1, 2], [3, 3]],
+                [[1, 2], [3, '3']],
                 [1, 2, 3, 3],
             ],
             [
-                [[1, 2], [3, 3], [4, 5, 5]],
+                [[1, 2], [3, '3'], [4, 5, 5]],
                 [1, 2, 3, 3, 4, 5, 5],
             ],
             [
-                [[1], [1, 1, 2], [1, 1, 1, 3]],
+                [[1], [1, 1, 2], [1, '1', 1, 3]],
                 [1, 1, 1, 2, 3],
             ],
             [
@@ -124,7 +124,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     [1, 1, 2.2, '3', true, null, [1], [1], (object)[1]],
                     [1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]],
                 ],
-                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+                [1, 1, 2.2, '3', true, false, INF, [1], [1], (object)[1], (object)[2]],
             ],
         ];
     }
@@ -141,7 +141,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
         $result = [];
 
         // When
-        foreach (Set::union(...$iterables) as $datum) {
+        foreach (Set::unionCoercive(...$iterables) as $datum) {
             $result[] = $datum;
         }
 
@@ -179,7 +179,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 2],
             ],
             [
-                [$gen([1, 2]), $gen([2, 3])],
+                [$gen(['1', '2']), $gen([2, 3])],
                 [1, 2, 3],
             ],
             [
@@ -187,7 +187,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 2, 3, 4],
             ],
             [
-                [$gen([1, 2]), $gen([3, 4]), $gen([4, 5])],
+                [$gen([1, 2]), $gen([3, 4]), $gen(['4', 5])],
                 [1, 2, 3, 4, 5],
             ],
             [
@@ -199,7 +199,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     $gen([1, 2.2, '3', true, null, [1], (object)[1]]),
                     $gen([1.0, 2.2, 3, false, INF, [1], (object)[2]]),
                 ],
-                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+                [1, 2.2, '3', true, false, INF, [1], (object)[1], (object)[2]],
             ],
         ];
     }
@@ -214,31 +214,31 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 1],
             ],
             [
-                [$gen([1]), $gen([1, 1])],
+                [$gen([1]), $gen([1, '1'])],
                 [1, 1],
             ],
             [
-                [$gen([1, 1]), $gen([1, 1])],
+                [$gen([1, '1']), $gen([1, 1])],
                 [1, 1],
             ],
             [
-                [$gen([1, 1, 1]), $gen([1, 1])],
+                [$gen([1, 1, 1]), $gen(['1', 1])],
                 [1, 1, 1],
             ],
             [
-                [$gen([1, 2]), $gen([1, 1])],
+                [$gen([1, 2]), $gen(['1', 1])],
                 [1, 1, 2],
             ],
             [
-                [$gen([1, 2]), $gen([3, 3])],
+                [$gen([1, 2]), $gen([3, '3'])],
                 [1, 2, 3, 3],
             ],
             [
-                [$gen([1, 2]), $gen([3, 3]), $gen([4, 5, 5])],
+                [$gen([1, 2]), $gen([3, '3']), $gen([4, 5, 5])],
                 [1, 2, 3, 3, 4, 5, 5],
             ],
             [
-                [$gen([1]), $gen([1, 1, 2]), $gen([1, 1, 1, 3])],
+                [$gen([1]), $gen([1, 1, 2]), $gen([1, '1', 1, 3])],
                 [1, 1, 1, 2, 3],
             ],
             [
@@ -246,7 +246,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     $gen([1, 1, 2.2, '3', true, null, [1], [1], (object)[1]]),
                     $gen([1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]]),
                 ],
-                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+                [1, 1, 2.2, '3', true, false, INF, [1], [1], (object)[1], (object)[2]],
             ],
         ];
     }
@@ -263,7 +263,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
         $result = [];
 
         // When
-        foreach (Set::union(...$iterables) as $datum) {
+        foreach (Set::unionCoercive(...$iterables) as $datum) {
             $result[] = $datum;
         }
 
@@ -301,7 +301,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 2],
             ],
             [
-                [$iter([1, 2]), $iter([2, 3])],
+                [$iter(['1', '2']), $iter([2, 3])],
                 [1, 2, 3],
             ],
             [
@@ -309,7 +309,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 2, 3, 4],
             ],
             [
-                [$iter([1, 2]), $iter([3, 4]), $iter([4, 5])],
+                [$iter([1, 2]), $iter([3, 4]), $iter(['4', 5])],
                 [1, 2, 3, 4, 5],
             ],
             [
@@ -321,7 +321,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     $iter([1, 2.2, '3', true, null, [1], (object)[1]]),
                     $iter([1.0, 2.2, 3, false, INF, [1], (object)[2]]),
                 ],
-                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+                [1, 2.2, '3', true, false, INF, [1], (object)[1], (object)[2]],
             ],
         ];
     }
@@ -336,31 +336,31 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 1],
             ],
             [
-                [$iter([1]), $iter([1, 1])],
+                [$iter([1]), $iter([1, '1'])],
                 [1, 1],
             ],
             [
-                [$iter([1, 1]), $iter([1, 1])],
+                [$iter([1, '1']), $iter([1, 1])],
                 [1, 1],
             ],
             [
-                [$iter([1, 1, 1]), $iter([1, 1])],
+                [$iter([1, 1, 1]), $iter(['1', 1])],
                 [1, 1, 1],
             ],
             [
-                [$iter([1, 2]), $iter([1, 1])],
+                [$iter([1, 2]), $iter(['1', 1])],
                 [1, 1, 2],
             ],
             [
-                [$iter([1, 2]), $iter([3, 3])],
+                [$iter([1, 2]), $iter([3, '3'])],
                 [1, 2, 3, 3],
             ],
             [
-                [$iter([1, 2]), $iter([3, 3]), $iter([4, 5, 5])],
+                [$iter([1, 2]), $iter([3, '3']), $iter([4, 5, 5])],
                 [1, 2, 3, 3, 4, 5, 5],
             ],
             [
-                [$iter([1]), $iter([1, 1, 2]), $iter([1, 1, 1, 3])],
+                [$iter([1]), $iter([1, 1, 2]), $iter([1, '1', 1, 3])],
                 [1, 1, 1, 2, 3],
             ],
             [
@@ -368,7 +368,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     $iter([1, 1, 2.2, '3', true, null, [1], [1], (object)[1]]),
                     $iter([1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]]),
                 ],
-                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+                [1, 1, 2.2, '3', true, false, INF, [1], [1], (object)[1], (object)[2]],
             ],
         ];
     }
@@ -385,7 +385,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
         $result = [];
 
         // When
-        foreach (Set::union(...$iterables) as $datum) {
+        foreach (Set::unionCoercive(...$iterables) as $datum) {
             $result[] = $datum;
         }
 
@@ -423,7 +423,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 2],
             ],
             [
-                [$trav([1, 2]), $trav([2, 3])],
+                [$trav(['1', '2']), $trav([2, 3])],
                 [1, 2, 3],
             ],
             [
@@ -431,7 +431,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 2, 3, 4],
             ],
             [
-                [$trav([1, 2]), $trav([3, 4]), $trav([4, 5])],
+                [$trav([1, 2]), $trav([3, 4]), $trav(['4', 5])],
                 [1, 2, 3, 4, 5],
             ],
             [
@@ -443,7 +443,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     $trav([1, 2.2, '3', true, null, [1], (object)[1]]),
                     $trav([1.0, 2.2, 3, false, INF, [1], (object)[2]]),
                 ],
-                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+                [1, 2.2, '3', true, false, INF, [1], (object)[1], (object)[2]],
             ],
         ];
     }
@@ -458,31 +458,31 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [1, 1],
             ],
             [
-                [$trav([1]), $trav([1, 1])],
+                [$trav([1]), $trav([1, '1'])],
                 [1, 1],
             ],
             [
-                [$trav([1, 1]), $trav([1, 1])],
+                [$trav([1, '1']), $trav([1, 1])],
                 [1, 1],
             ],
             [
-                [$trav([1, 1, 1]), $trav([1, 1])],
+                [$trav([1, 1, 1]), $trav(['1', 1])],
                 [1, 1, 1],
             ],
             [
-                [$trav([1, 2]), $trav([1, 1])],
+                [$trav([1, 2]), $trav(['1', 1])],
                 [1, 1, 2],
             ],
             [
-                [$trav([1, 2]), $trav([3, 3])],
+                [$trav([1, 2]), $trav([3, '3'])],
                 [1, 2, 3, 3],
             ],
             [
-                [$trav([1, 2]), $trav([3, 3]), $trav([4, 5, 5])],
+                [$trav([1, 2]), $trav([3, '3']), $trav([4, 5, 5])],
                 [1, 2, 3, 3, 4, 5, 5],
             ],
             [
-                [$trav([1]), $trav([1, 1, 2]), $trav([1, 1, 1, 3])],
+                [$trav([1]), $trav([1, 1, 2]), $trav([1, '1', 1, 3])],
                 [1, 1, 1, 2, 3],
             ],
             [
@@ -490,10 +490,11 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     $trav([1, 1, 2.2, '3', true, null, [1], [1], (object)[1]]),
                     $trav([1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]]),
                 ],
-                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+                [1, 1, 2.2, '3', true, false, INF, [1], [1], (object)[1], (object)[2]],
             ],
         ];
     }
+
 
     /**
      * @dataProvider dataProviderForMixedSets
@@ -507,7 +508,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
         $result = [];
 
         // When
-        foreach (Set::union(...$iterables) as $datum) {
+        foreach (Set::unionCoercive(...$iterables) as $datum) {
             $result[] = $datum;
         }
 
@@ -527,7 +528,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                 [],
             ],
             [
-                [[1], $gen([1, 2]), $iter([3, 4]), $trav([4, 5])],
+                [[1], $gen(['1', 2]), $iter([3, 4]), $trav([4, 5])],
                 [1, 2, 3, 4, 5],
             ],
             [
@@ -541,7 +542,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     $iter([1.0, 2.2, 3, false, INF, [1], (object)[2]]),
                     $trav([1.0, 2.2, 3, false, INF, [1]]),
                 ],
-                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+                [1, 2.2, '3', true, false, INF, [1], (object)[1], (object)[2]],
             ],
         ];
     }
@@ -554,23 +555,23 @@ class UnionTest extends \PHPUnit\Framework\TestCase
 
         return [
             [
-                [[], $gen([]), $iter([]), $trav([1, 1])],
+                [[], $gen([]), $iter([]), $trav([1, '1'])],
                 [1, 1],
             ],
             [
-                [[1, 1], $gen([1, 1]), $iter([1, 1]), $trav([1, 1])],
+                [[1, '1'], $gen([1, 1]), $iter(['1', 1]), $trav([1, 1])],
                 [1, 1],
             ],
             [
-                [[1], $gen([]), $iter([1, 1, 1]), $trav([1, 1])],
+                [[1], $gen([]), $iter([1, '1', 1]), $trav([1, 1])],
                 [1, 1, 1],
             ],
             [
-                [[1, 1], $gen([1, 2]), $iter([3, 3]), $trav([4, 5, 5])],
+                [[1, '1'], $gen([1, 2]), $iter([3, 3]), $trav([4, 5, 5])],
                 [1, 1, 2, 3, 3, 4, 5, 5],
             ],
             [
-                [[1, 2], $gen([1]), $iter([1, 1, 2]), $trav([1, 1, 1, 3])],
+                [[1, 2], $gen([1]), $iter([1, '1', 2]), $trav([1, '1', '1', 3])],
                 [1, 1, 1, 2, 3],
             ],
             [
@@ -580,7 +581,7 @@ class UnionTest extends \PHPUnit\Framework\TestCase
                     $iter([1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]]),
                     $trav([1.0, 1.0, 2.2, 3, false, INF, [1]]),
                 ],
-                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+                [1, 1, 2.2, '3', true, false, INF, [1], [1], (object)[1], (object)[2]],
             ],
         ];
     }

--- a/tests/Set/UnionTest.php
+++ b/tests/Set/UnionTest.php
@@ -1,0 +1,587 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IterTools\Tests\Set;
+
+use IterTools\Set;
+use IterTools\Tests\Fixture\ArrayIteratorFixture;
+use IterTools\Tests\Fixture\GeneratorFixture;
+use IterTools\Tests\Fixture\IteratorAggregateFixture;
+
+class UnionTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider dataProviderForArraySets
+     * @dataProvider dataProviderForArrayMultisets
+     * @param        array<array> $iterables
+     * @param        array $expected
+     */
+    public function testArray(array $iterables, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Set::union(...$iterables) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEqualsCanonicalizing($expected, $result);
+    }
+
+    public function dataProviderForArraySets(): array
+    {
+        return [
+            [
+                [],
+                [],
+            ],
+            [
+                [[]],
+                [],
+            ],
+            [
+                [[], []],
+                [],
+            ],
+            [
+                [[], [], []],
+                [],
+            ],
+            [
+                [[1]],
+                [1],
+            ],
+            [
+                [[1, 2]],
+                [1, 2],
+            ],
+            [
+                [[1, 2], [2, 3]],
+                [1, 2, 3],
+            ],
+            [
+                [[1, 2], [3, 4]],
+                [1, 2, 3, 4],
+            ],
+            [
+                [[1, 2], [3, 4], [4, 5]],
+                [1, 2, 3, 4, 5],
+            ],
+            [
+                [[1, 2], [3, 4], [5, 6]],
+                [1, 2, 3, 4, 5, 6],
+            ],
+            [
+                [
+                    [1, 2.2, '3', true, null, [1], (object)[1]],
+                    [1.0, 2.2, 3, false, INF, [1], (object)[2]],
+                ],
+                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    public function dataProviderForArrayMultisets(): array
+    {
+        return [
+            [
+                [[], [1, 1]],
+                [1, 1],
+            ],
+            [
+                [[1], [1, 1]],
+                [1, 1],
+            ],
+            [
+                [[1, 1], [1, 1]],
+                [1, 1],
+            ],
+            [
+                [[1, 1, 1], [1, 1]],
+                [1, 1, 1],
+            ],
+            [
+                [[1, 2], [1, 1]],
+                [1, 1, 2],
+            ],
+            [
+                [[1, 2], [3, 3]],
+                [1, 2, 3, 3],
+            ],
+            [
+                [[1, 2], [3, 3], [4, 5, 5]],
+                [1, 2, 3, 3, 4, 5, 5],
+            ],
+            [
+                [[1], [1, 1, 2], [1, 1, 1, 3]],
+                [1, 1, 1, 2, 3],
+            ],
+            [
+                [
+                    [1, 1, 2.2, '3', true, null, [1], [1], (object)[1]],
+                    [1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]],
+                ],
+                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForGeneratorsSets
+     * @dataProvider dataProviderForGeneratorsMultisets
+     * @param        array<\Generator> $iterables
+     * @param        array $expected
+     */
+    public function testGenerators(array $iterables, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Set::union(...$iterables) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEqualsCanonicalizing($expected, $result);
+    }
+
+    public function dataProviderForGeneratorsSets(): array
+    {
+        $gen = fn ($data) => GeneratorFixture::getGenerator($data);
+
+        return [
+            [
+                [],
+                [],
+            ],
+            [
+                [$gen([])],
+                [],
+            ],
+            [
+                [$gen([]), $gen([])],
+                [],
+            ],
+            [
+                [$gen([]), $gen([]), $gen([])],
+                [],
+            ],
+            [
+                [$gen([1])],
+                [1],
+            ],
+            [
+                [$gen([1, 2])],
+                [1, 2],
+            ],
+            [
+                [$gen([1, 2]), $gen([2, 3])],
+                [1, 2, 3],
+            ],
+            [
+                [$gen([1, 2]), $gen([3, 4])],
+                [1, 2, 3, 4],
+            ],
+            [
+                [$gen([1, 2]), $gen([3, 4]), $gen([4, 5])],
+                [1, 2, 3, 4, 5],
+            ],
+            [
+                [$gen([1, 2]), $gen([3, 4]), $gen([5, 6])],
+                [1, 2, 3, 4, 5, 6],
+            ],
+            [
+                [
+                    $gen([1, 2.2, '3', true, null, [1], (object)[1]]),
+                    $gen([1.0, 2.2, 3, false, INF, [1], (object)[2]]),
+                ],
+                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    public function dataProviderForGeneratorsMultisets(): array
+    {
+        $gen = fn ($data) => GeneratorFixture::getGenerator($data);
+
+        return [
+            [
+                [$gen([]), $gen([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$gen([1]), $gen([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$gen([1, 1]), $gen([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$gen([1, 1, 1]), $gen([1, 1])],
+                [1, 1, 1],
+            ],
+            [
+                [$gen([1, 2]), $gen([1, 1])],
+                [1, 1, 2],
+            ],
+            [
+                [$gen([1, 2]), $gen([3, 3])],
+                [1, 2, 3, 3],
+            ],
+            [
+                [$gen([1, 2]), $gen([3, 3]), $gen([4, 5, 5])],
+                [1, 2, 3, 3, 4, 5, 5],
+            ],
+            [
+                [$gen([1]), $gen([1, 1, 2]), $gen([1, 1, 1, 3])],
+                [1, 1, 1, 2, 3],
+            ],
+            [
+                [
+                    $gen([1, 1, 2.2, '3', true, null, [1], [1], (object)[1]]),
+                    $gen([1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]]),
+                ],
+                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForIteratorsSets
+     * @dataProvider dataProviderForIteratorsMultisets
+     * @param        array<\Iterator> $iterables
+     * @param        array $expected
+     */
+    public function testIterators(array $iterables, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Set::union(...$iterables) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEqualsCanonicalizing($expected, $result);
+    }
+
+    public function dataProviderForIteratorsSets(): array
+    {
+        $iter = fn ($data) => new ArrayIteratorFixture($data);
+
+        return [
+            [
+                [],
+                [],
+            ],
+            [
+                [$iter([])],
+                [],
+            ],
+            [
+                [$iter([]), $iter([])],
+                [],
+            ],
+            [
+                [$iter([]), $iter([]), $iter([])],
+                [],
+            ],
+            [
+                [$iter([1])],
+                [1],
+            ],
+            [
+                [$iter([1, 2])],
+                [1, 2],
+            ],
+            [
+                [$iter([1, 2]), $iter([2, 3])],
+                [1, 2, 3],
+            ],
+            [
+                [$iter([1, 2]), $iter([3, 4])],
+                [1, 2, 3, 4],
+            ],
+            [
+                [$iter([1, 2]), $iter([3, 4]), $iter([4, 5])],
+                [1, 2, 3, 4, 5],
+            ],
+            [
+                [$iter([1, 2]), $iter([3, 4]), $iter([5, 6])],
+                [1, 2, 3, 4, 5, 6],
+            ],
+            [
+                [
+                    $iter([1, 2.2, '3', true, null, [1], (object)[1]]),
+                    $iter([1.0, 2.2, 3, false, INF, [1], (object)[2]]),
+                ],
+                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    public function dataProviderForIteratorsMultisets(): array
+    {
+        $iter = fn ($data) => new ArrayIteratorFixture($data);
+
+        return [
+            [
+                [$iter([]), $iter([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$iter([1]), $iter([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$iter([1, 1]), $iter([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$iter([1, 1, 1]), $iter([1, 1])],
+                [1, 1, 1],
+            ],
+            [
+                [$iter([1, 2]), $iter([1, 1])],
+                [1, 1, 2],
+            ],
+            [
+                [$iter([1, 2]), $iter([3, 3])],
+                [1, 2, 3, 3],
+            ],
+            [
+                [$iter([1, 2]), $iter([3, 3]), $iter([4, 5, 5])],
+                [1, 2, 3, 3, 4, 5, 5],
+            ],
+            [
+                [$iter([1]), $iter([1, 1, 2]), $iter([1, 1, 1, 3])],
+                [1, 1, 1, 2, 3],
+            ],
+            [
+                [
+                    $iter([1, 1, 2.2, '3', true, null, [1], [1], (object)[1]]),
+                    $iter([1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]]),
+                ],
+                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTraversablesSets
+     * @dataProvider dataProviderForTraversablesMultisets
+     * @param        array<\Traversable> $iterables
+     * @param        array $expected
+     */
+    public function testTraversables(array $iterables, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Set::union(...$iterables) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEqualsCanonicalizing($expected, $result);
+    }
+
+    public function dataProviderForTraversablesSets(): array
+    {
+        $trav = fn ($data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                [],
+                [],
+            ],
+            [
+                [$trav([])],
+                [],
+            ],
+            [
+                [$trav([]), $trav([])],
+                [],
+            ],
+            [
+                [$trav([]), $trav([]), $trav([])],
+                [],
+            ],
+            [
+                [$trav([1])],
+                [1],
+            ],
+            [
+                [$trav([1, 2])],
+                [1, 2],
+            ],
+            [
+                [$trav([1, 2]), $trav([2, 3])],
+                [1, 2, 3],
+            ],
+            [
+                [$trav([1, 2]), $trav([3, 4])],
+                [1, 2, 3, 4],
+            ],
+            [
+                [$trav([1, 2]), $trav([3, 4]), $trav([4, 5])],
+                [1, 2, 3, 4, 5],
+            ],
+            [
+                [$trav([1, 2]), $trav([3, 4]), $trav([5, 6])],
+                [1, 2, 3, 4, 5, 6],
+            ],
+            [
+                [
+                    $trav([1, 2.2, '3', true, null, [1], (object)[1]]),
+                    $trav([1.0, 2.2, 3, false, INF, [1], (object)[2]]),
+                ],
+                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    public function dataProviderForTraversablesMultisets(): array
+    {
+        $trav = fn ($data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                [$trav([]), $trav([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$trav([1]), $trav([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$trav([1, 1]), $trav([1, 1])],
+                [1, 1],
+            ],
+            [
+                [$trav([1, 1, 1]), $trav([1, 1])],
+                [1, 1, 1],
+            ],
+            [
+                [$trav([1, 2]), $trav([1, 1])],
+                [1, 1, 2],
+            ],
+            [
+                [$trav([1, 2]), $trav([3, 3])],
+                [1, 2, 3, 3],
+            ],
+            [
+                [$trav([1, 2]), $trav([3, 3]), $trav([4, 5, 5])],
+                [1, 2, 3, 3, 4, 5, 5],
+            ],
+            [
+                [$trav([1]), $trav([1, 1, 2]), $trav([1, 1, 1, 3])],
+                [1, 1, 1, 2, 3],
+            ],
+            [
+                [
+                    $trav([1, 1, 2.2, '3', true, null, [1], [1], (object)[1]]),
+                    $trav([1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]]),
+                ],
+                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForMixedSets
+     * @dataProvider dataProviderForMixedMultisets
+     * @param        array<iterable> $iterables
+     * @param        array $expected
+     */
+    public function testMixed(array $iterables, array $expected): void
+    {
+        // Given
+        $result = [];
+
+        // When
+        foreach (Set::union(...$iterables) as $datum) {
+            $result[] = $datum;
+        }
+
+        // Then
+        $this->assertEqualsCanonicalizing($expected, $result);
+    }
+
+    public function dataProviderForMixedSets(): array
+    {
+        $gen = fn ($data) => GeneratorFixture::getGenerator($data);
+        $iter = fn ($data) => new ArrayIteratorFixture($data);
+        $trav = fn ($data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                [[], $gen([]), $trav([]), $trav([])],
+                [],
+            ],
+            [
+                [[1], $gen([1, 2]), $iter([3, 4]), $trav([4, 5])],
+                [1, 2, 3, 4, 5],
+            ],
+            [
+                [$trav([1, 2]), $trav([3, 4]), $trav([5, 6]), [7, 8]],
+                [1, 2, 3, 4, 5, 6, 7, 8],
+            ],
+            [
+                [
+                    [1, 2.2, '3', true, null, [1]],
+                    $gen([1, 2.2, '3', true, null, [1], (object)[1]]),
+                    $iter([1.0, 2.2, 3, false, INF, [1], (object)[2]]),
+                    $trav([1.0, 2.2, 3, false, INF, [1]]),
+                ],
+                [1, 1.0, 2.2, '3', 3, true, false, null, INF, [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+
+    public function dataProviderForMixedMultisets(): array
+    {
+        $gen = fn ($data) => GeneratorFixture::getGenerator($data);
+        $iter = fn ($data) => new ArrayIteratorFixture($data);
+        $trav = fn ($data) => new IteratorAggregateFixture($data);
+
+        return [
+            [
+                [[], $gen([]), $iter([]), $trav([1, 1])],
+                [1, 1],
+            ],
+            [
+                [[1, 1], $gen([1, 1]), $iter([1, 1]), $trav([1, 1])],
+                [1, 1],
+            ],
+            [
+                [[1], $gen([]), $iter([1, 1, 1]), $trav([1, 1])],
+                [1, 1, 1],
+            ],
+            [
+                [[1, 1], $gen([1, 2]), $iter([3, 3]), $trav([4, 5, 5])],
+                [1, 1, 2, 3, 3, 4, 5, 5],
+            ],
+            [
+                [[1, 2], $gen([1]), $iter([1, 1, 2]), $trav([1, 1, 1, 3])],
+                [1, 1, 1, 2, 3],
+            ],
+            [
+                [
+                    [1, 1, 2.2, '3', true, null, [1], [1]],
+                    $gen([1, 1, 2.2, '3', true, null, [1], [1], (object)[1]]),
+                    $iter([1.0, 1.0, 2.2, 3, false, INF, [1], (object)[2]]),
+                    $trav([1.0, 1.0, 2.2, 3, false, INF, [1]]),
+                ],
+                [1, 1, 1.0, 1.0, 2.2, '3', 3, true, false, null, INF, [1], [1], (object)[1], (object)[2]],
+            ],
+        ];
+    }
+}

--- a/tests/Stream/SetTest.php
+++ b/tests/Stream/SetTest.php
@@ -198,6 +198,50 @@ class SetTest extends \PHPUnit\Framework\TestCase
                     ->toArray(),
                 [4, 5, 6, 7, 8, 9],
             ],
+            [
+                [
+                    [],
+                    [2, 3, 4, 5, 6],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionWith(...$iterables)
+                    ->toArray(),
+                [2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    [1, 2, 3, 4, 5],
+                    [2, 3, 4, 5, 6],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionWith(...$iterables)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    [],
+                    [2, 3, '4', 5, '6'],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionCoerciveWith(...$iterables)
+                    ->toArray(),
+                [2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    [1, '2', 3, '4', 5],
+                    [2, '3', 4, '5', '6'],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionCoerciveWith(...$iterables)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7],
+            ],
         ];
     }
 
@@ -584,6 +628,50 @@ class SetTest extends \PHPUnit\Framework\TestCase
                     ->symmetricDifferenceCoerciveWith(...$iterables)
                     ->toArray(),
                 [4, 5, 6, 7, 8, 9],
+            ],
+            [
+                [
+                    $gen([]),
+                    [2, 3, 4, 5, 6],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionWith(...$iterables)
+                    ->toArray(),
+                [2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $gen([1, 2, 3, 4, 5]),
+                    [2, 3, 4, 5, 6],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionWith(...$iterables)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $gen([]),
+                    [2, 3, '4', 5, '6'],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionCoerciveWith(...$iterables)
+                    ->toArray(),
+                [2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $gen([1, '2', 3, '4', 5]),
+                    [2, '3', 4, '5', '6'],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionCoerciveWith(...$iterables)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7],
             ],
         ];
     }
@@ -974,6 +1062,50 @@ class SetTest extends \PHPUnit\Framework\TestCase
                     ->toArray(),
                 [4, 5, 6, 7, 8, 9],
             ],
+            [
+                [
+                    $iter([]),
+                    [2, 3, 4, 5, 6],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionWith(...$iterables)
+                    ->toArray(),
+                [2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $iter([1, 2, 3, 4, 5]),
+                    [2, 3, 4, 5, 6],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionWith(...$iterables)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $iter([]),
+                    [2, 3, '4', 5, '6'],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionCoerciveWith(...$iterables)
+                    ->toArray(),
+                [2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $iter([1, '2', 3, '4', 5]),
+                    [2, '3', 4, '5', '6'],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionCoerciveWith(...$iterables)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7],
+            ],
         ];
     }
 
@@ -1362,6 +1494,50 @@ class SetTest extends \PHPUnit\Framework\TestCase
                     ->symmetricDifferenceCoerciveWith(...$iterables)
                     ->toArray(),
                 [4, 5, 6, 7, 8, 9],
+            ],
+            [
+                [
+                    $trav([]),
+                    [2, 3, 4, 5, 6],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionWith(...$iterables)
+                    ->toArray(),
+                [2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $trav([1, 2, 3, 4, 5]),
+                    [2, 3, 4, 5, 6],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionWith(...$iterables)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $trav([]),
+                    [2, 3, '4', 5, '6'],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionCoerciveWith(...$iterables)
+                    ->toArray(),
+                [2, 3, 4, 5, 6, 7],
+            ],
+            [
+                [
+                    $trav([1, '2', 3, '4', 5]),
+                    [2, '3', 4, '5', '6'],
+                    [3, 4, 5, 6, 7],
+                ],
+                fn (array $iterables) => Stream::of(array_shift($iterables))
+                    ->unionCoerciveWith(...$iterables)
+                    ->toArray(),
+                [1, 2, 3, 4, 5, 6, 7],
             ],
         ];
     }


### PR DESCRIPTION
Hi @markrogoyski,

I've added new methods and covered them by tests:
* `Set::union()`
* `Set::unionCoercive()`
* `Stream::unionWith()`
* `Stream::unionCoerciveWith()`
