### PR TITLE
Add explicit nullable type to parameters.

### DIFF
--- a/src/Reduce.php
+++ b/src/Reduce.php
@@ -44,7 +44,7 @@ class Reduce
      *
      * @return mixed|null
      */
-    public static function toMin(iterable $data, callable $compareBy = null)
+    public static function toMin(iterable $data, ?callable $compareBy = null)
     {
         if ($compareBy !== null) {
             return static::toValue(
@@ -71,7 +71,7 @@ class Reduce
      *
      * @return mixed|null
      */
-    public static function toMax(iterable $data, callable $compareBy = null)
+    public static function toMax(iterable $data, ?callable $compareBy = null)
     {
         if ($compareBy !== null) {
             return static::toValue(
@@ -99,7 +99,7 @@ class Reduce
      *
      * @return array{numeric, numeric}|array{null, null}
      */
-    public static function toMinMax(iterable $numbers, callable $compareBy = null): array
+    public static function toMinMax(iterable $numbers, ?callable $compareBy = null): array
     {
         if ($compareBy !== null) {
             return static::toValue($numbers, static function (array $carry, $datum) use ($compareBy) {

--- a/src/Single.php
+++ b/src/Single.php
@@ -150,7 +150,7 @@ class Single
      *
      * @return \Generator<mixed>
      */
-    public static function filterFalse(iterable $data, callable $predicate = null): \Generator
+    public static function filterFalse(iterable $data, ?callable $predicate = null): \Generator
     {
         if ($predicate === null) {
             $predicate = fn($datum): bool => \boolval($datum);
@@ -173,7 +173,7 @@ class Single
      *
      * @return \Generator<mixed>
      */
-    public static function filterTrue(iterable $data, callable $predicate = null): \Generator
+    public static function filterTrue(iterable $data, ?callable $predicate = null): \Generator
     {
         if ($predicate === null) {
             $predicate = fn($datum): bool => \boolval($datum);
@@ -244,7 +244,7 @@ class Single
     public static function groupBy(
         iterable $data,
         callable $groupKeyFunction,
-        callable $itemKeyFunction = null
+        ?callable $itemKeyFunction = null
     ): \Generator {
         $itemKeyFunction ??= fn ($x) => null;
         $groups = [];
@@ -473,7 +473,7 @@ class Single
      *
      * @return \Generator<T>
      */
-    public static function slice(iterable $data, int $start = 0, int $count = null, int $step = 1): \Generator
+    public static function slice(iterable $data, int $start = 0, ?int $count = null, int $step = 1): \Generator
     {
         if ($start < 0) {
             throw new \InvalidArgumentException("Parameter 'start' cannot be negative");

--- a/src/Sort.php
+++ b/src/Sort.php
@@ -16,7 +16,7 @@ class Sort
      *
      * @return \Generator
      */
-    public static function asort(iterable $data, callable $comparator = null): \Generator
+    public static function asort(iterable $data, ?callable $comparator = null): \Generator
     {
         $array = \iterator_to_array(Transform::toIterator($data), true);
 
@@ -41,7 +41,7 @@ class Sort
      *
      * @return \Generator
      */
-    public static function sort(iterable $data, callable $comparator = null): \Generator
+    public static function sort(iterable $data, ?callable $comparator = null): \Generator
     {
         $array = \iterator_to_array(Transform::toIterator($data));
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -292,7 +292,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Single::filterTrue()
      */
-    public function filterTrue(callable $predicate = null): self
+    public function filterTrue(?callable $predicate = null): self
     {
         $this->iterable = Single::filterTrue($this->iterable, $predicate);
         return $this;
@@ -309,7 +309,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Single::filterFalse()
      */
-    public function filterFalse(callable $predicate = null): self
+    public function filterFalse(?callable $predicate = null): self
     {
         $this->iterable = Single::filterFalse($this->iterable, $predicate);
         return $this;
@@ -344,7 +344,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Single::groupBy()
      */
-    public function groupBy(callable $groupKeyFunction, callable $itemKeyFunction = null): self
+    public function groupBy(callable $groupKeyFunction, ?callable $itemKeyFunction = null): self
     {
         $this->iterable = Single::groupBy($this->iterable, $groupKeyFunction, $itemKeyFunction);
         return $this;
@@ -475,7 +475,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Single::slice()
      */
-    public function slice(int $start = 0, int $count = null, int $step = 1): self
+    public function slice(int $start = 0, ?int $count = null, int $step = 1): self
     {
         $this->iterable = Single::slice($this->iterable, $start, $count, $step);
         return $this;
@@ -536,7 +536,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Single::sort()
      */
-    public function sort(callable $comparator = null): self
+    public function sort(?callable $comparator = null): self
     {
         $this->iterable = Sort::sort($this->iterable, $comparator);
         return $this;
@@ -553,7 +553,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Single::asort()
      */
-    public function asort(callable $comparator = null): self
+    public function asort(?callable $comparator = null): self
     {
         $this->iterable = Sort::asort($this->iterable, $comparator);
         return $this;
@@ -1074,7 +1074,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Transform::toAssociativeArray()
      */
-    public function toAssociativeArray(callable $keyFunc = null, callable $valueFunc = null): array
+    public function toAssociativeArray(?callable $keyFunc = null, ?callable $valueFunc = null): array
     {
         return Transform::toAssociativeArray($this->iterable, $keyFunc, $valueFunc);
     }
@@ -1112,7 +1112,7 @@ class Stream implements \IteratorAggregate
      *
      * @return void
      */
-    public function toFile($fileResource, string $newlineSeparator = \PHP_EOL, string $header = null, string $footer = null): void
+    public function toFile($fileResource, string $newlineSeparator = \PHP_EOL, ?string $header = null, ?string $footer = null): void
     {
         ResourcePolicy::assertIsSatisfied($fileResource);
 
@@ -1154,7 +1154,7 @@ class Stream implements \IteratorAggregate
      */
     public function toCsvFile(
         $fileResource,
-        array $header = null,
+        ?array $header = null,
         string $separator = ',',
         string $enclosure = '"',
         string $escape = '\\'
@@ -1215,7 +1215,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Summary::exactlyN()
      */
-    public function exactlyN(int $n, callable $predicate = null): bool
+    public function exactlyN(int $n, ?callable $predicate = null): bool
     {
         return Summary::exactlyN($this->iterable, $n, $predicate);
     }
@@ -1236,7 +1236,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Summary::isPartitioned()
      */
-    public function isPartitioned(callable $predicate = null): bool
+    public function isPartitioned(?callable $predicate = null): bool
     {
         return Summary::isPartitioned($this->iterable, $predicate);
     }
@@ -1436,7 +1436,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Reduce::toMax()
      */
-    public function toMax(callable $compareBy = null)
+    public function toMax(?callable $compareBy = null)
     {
         return Reduce::toMax($this->iterable, $compareBy);
     }
@@ -1456,7 +1456,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Reduce::toMin()
      */
-    public function toMin(callable $compareBy = null)
+    public function toMin(?callable $compareBy = null)
     {
         return Reduce::toMin($this->iterable, $compareBy);
     }
@@ -1476,7 +1476,7 @@ class Stream implements \IteratorAggregate
      *
      * @see Reduce::toMinMax()
      */
-    public function toMinMax(callable $compareBy = null): array
+    public function toMinMax(?callable $compareBy = null): array
     {
         /** @var iterable<numeric> $iterable */
         $iterable = $this->iterable;

--- a/src/Summary.php
+++ b/src/Summary.php
@@ -198,7 +198,7 @@ class Summary
      *
      * @return bool
      */
-    public static function exactlyN(iterable $data, int $n, callable $predicate = null): bool
+    public static function exactlyN(iterable $data, int $n, ?callable $predicate = null): bool
     {
         if ($n < 0) {
             return false;
@@ -318,7 +318,7 @@ class Summary
      *
      * @return bool
      */
-    public static function isPartitioned(iterable $data, callable $predicate = null): bool
+    public static function isPartitioned(iterable $data, ?callable $predicate = null): bool
     {
         $predicate ??= fn ($item): bool => \boolval($item);
 

--- a/src/Transform.php
+++ b/src/Transform.php
@@ -40,8 +40,8 @@ class Transform
      */
     public static function toAssociativeArray(
         iterable $iterable,
-        callable $keyFunc = null,
-        callable $valueFunc = null
+        ?callable $keyFunc = null,
+        ?callable $valueFunc = null
     ): array {
         if ($keyFunc === null) {
             $keyFunc = fn ($item, $key) => $key;

--- a/src/Util/Iterators/TeeIterator.php
+++ b/src/Util/Iterators/TeeIterator.php
@@ -64,7 +64,7 @@ class TeeIterator extends \NoRewindIterator
      *
      * @param RelatedIterator<TKey, TValue>|null $related
      */
-    public function next(RelatedIterator $related = null): void
+    public function next(?RelatedIterator $related = null): void
     {
         if ($related === null) {
             throw new \LogicException();
@@ -98,7 +98,7 @@ class TeeIterator extends \NoRewindIterator
      * @param RelatedIterator<TKey, TValue>|null $related
      */
     #[\ReturnTypeWillChange]
-    public function current(RelatedIterator $related = null)
+    public function current(?RelatedIterator $related = null)
     {
         if ($related === null) {
             throw new \LogicException();
@@ -115,7 +115,7 @@ class TeeIterator extends \NoRewindIterator
      * @return TKey
      */
     #[\ReturnTypeWillChange]
-    public function key(RelatedIterator $related = null)
+    public function key(?RelatedIterator $related = null)
     {
         if ($related === null) {
             throw new \LogicException();
@@ -129,7 +129,7 @@ class TeeIterator extends \NoRewindIterator
      *
      * @param RelatedIterator<TKey, TValue>|null $related
      */
-    public function valid(RelatedIterator $related = null): bool
+    public function valid(?RelatedIterator $related = null): bool
     {
         if ($related === null) {
             throw new \LogicException();


### PR DESCRIPTION
php8.4 deprecated implicit nullable parameters. This PR updates function signatures to include `?`-type where necessary.

This change should not affect anything since the implementations already accounted for the parameters to be `null`, only the correct type-hint was missing, which is a feature introduced in php7.1.
